### PR TITLE
Feat : 프로필 수정/조회 기능 구현

### DIFF
--- a/src/main/java/ewha/capston/cockChat/domain/member/controller/MemberController.java
+++ b/src/main/java/ewha/capston/cockChat/domain/member/controller/MemberController.java
@@ -1,15 +1,16 @@
 package ewha.capston.cockChat.domain.member.controller;
 
+import ewha.capston.cockChat.domain.member.domain.Member;
+import ewha.capston.cockChat.domain.member.dto.request.MemberUpdateRequestDto;
+import ewha.capston.cockChat.domain.member.dto.response.MemberResponseDto;
 import ewha.capston.cockChat.domain.member.service.AuthService;
 import ewha.capston.cockChat.domain.member.service.MemberService;
 import ewha.capston.cockChat.domain.member.dto.request.LoginRequestDto;
 import ewha.capston.cockChat.domain.member.dto.response.LoginResponseDto;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
 
 import java.io.IOException;
 
@@ -27,6 +28,13 @@ public class MemberController {
     public LoginResponseDto login(@RequestBody LoginRequestDto requestDto) throws IOException {
         LoginResponseDto responseDto = authService.googleLogin(requestDto.getCode());
         return responseDto;
+    }
+
+    @PutMapping("/members/profile")
+    public ResponseEntity<MemberResponseDto> updateMember(@RequestBody MemberUpdateRequestDto requestDto){
+
+        Member member = new Member("test@email.com","testName");
+        return memberService.updateMember(member,requestDto);
     }
 
 

--- a/src/main/java/ewha/capston/cockChat/domain/member/controller/MemberController.java
+++ b/src/main/java/ewha/capston/cockChat/domain/member/controller/MemberController.java
@@ -7,6 +7,7 @@ import ewha.capston.cockChat.domain.member.service.AuthService;
 import ewha.capston.cockChat.domain.member.service.MemberService;
 import ewha.capston.cockChat.domain.member.dto.request.LoginRequestDto;
 import ewha.capston.cockChat.domain.member.dto.response.LoginResponseDto;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -30,11 +31,18 @@ public class MemberController {
         return responseDto;
     }
 
+    /* 프로필 업데이트 */
     @PutMapping("/members/profile")
     public ResponseEntity<MemberResponseDto> updateMember(@RequestBody MemberUpdateRequestDto requestDto){
-
-        Member member = new Member("test@email.com","testName");
+        Member member = new Member("test@email.com","testName"); // 수정
         return memberService.updateMember(member,requestDto);
+    }
+
+    /* 프로필 조회 */
+    @GetMapping("/members/my")
+    public ResponseEntity<MemberResponseDto> getMemberProfile(){
+        Member member = new Member("test@email.com","testName"); // 수정
+        return memberService.getMemberProfile(member);
     }
 
 

--- a/src/main/java/ewha/capston/cockChat/domain/member/domain/Member.java
+++ b/src/main/java/ewha/capston/cockChat/domain/member/domain/Member.java
@@ -27,4 +27,14 @@ public class Member {
         this.email = email;
         this.nickname = nickname;
     }
+
+    /* 닉네임 수정 */
+    public void updateNickname(String nickname){
+        this.nickname = nickname;
+    }
+
+    /* 프로필 수정 */
+    public void updateProfileImgUrl(String profileImgUrl){
+        this.profileImgUrl = profileImgUrl;
+    }
 }

--- a/src/main/java/ewha/capston/cockChat/domain/member/dto/request/MemberUpdateRequestDto.java
+++ b/src/main/java/ewha/capston/cockChat/domain/member/dto/request/MemberUpdateRequestDto.java
@@ -1,0 +1,11 @@
+package ewha.capston.cockChat.domain.member.dto.request;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class MemberUpdateRequestDto {
+    private String nickname;
+    private String profileImgUrl;
+}

--- a/src/main/java/ewha/capston/cockChat/domain/member/dto/response/MemberResponseDto.java
+++ b/src/main/java/ewha/capston/cockChat/domain/member/dto/response/MemberResponseDto.java
@@ -1,0 +1,26 @@
+package ewha.capston.cockChat.domain.member.dto.response;
+
+import ewha.capston.cockChat.domain.member.domain.Member;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+public class MemberResponseDto {
+    private Long memberId;
+    private String email;
+    private String nickname;
+    private String profileImgUrl;
+
+    public static MemberResponseDto of(Member member){
+        return MemberResponseDto.builder()
+                .memberId(1L) // 이후 수정
+                .email(member.getEmail())
+                .nickname(member.getNickname())
+                .profileImgUrl(member.getProfileImgUrl())
+                .build();
+    }
+}

--- a/src/main/java/ewha/capston/cockChat/domain/member/service/MemberService.java
+++ b/src/main/java/ewha/capston/cockChat/domain/member/service/MemberService.java
@@ -3,11 +3,15 @@ package ewha.capston.cockChat.domain.member.service;
 
 import ewha.capston.cockChat.domain.member.auth.GoogleUser;
 import ewha.capston.cockChat.domain.member.domain.Member;
+import ewha.capston.cockChat.domain.member.dto.request.MemberUpdateRequestDto;
+import ewha.capston.cockChat.domain.member.dto.response.MemberResponseDto;
 import ewha.capston.cockChat.domain.member.repository.MemberRepository;
 import ewha.capston.cockChat.global.exception.CustomException;
 import ewha.capston.cockChat.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -61,5 +65,11 @@ public class MemberService {
                 .orElseThrow(()->new CustomException(ErrorCode.NO_MEMBER_EXIST));
     }
 
-
+    /* 회원 프로필 수정(실명) */
+    public ResponseEntity<MemberResponseDto> updateMember(Member member, MemberUpdateRequestDto requestDto) {
+        member.updateNickname(requestDto.getNickname());
+        member.updateProfileImgUrl(requestDto.getProfileImgUrl());
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(MemberResponseDto.of(member));
+    }
 }

--- a/src/main/java/ewha/capston/cockChat/domain/member/service/MemberService.java
+++ b/src/main/java/ewha/capston/cockChat/domain/member/service/MemberService.java
@@ -72,4 +72,10 @@ public class MemberService {
         return ResponseEntity.status(HttpStatus.OK)
                 .body(MemberResponseDto.of(member));
     }
+
+    /* 회원 프로필 조회 */
+    public ResponseEntity<MemberResponseDto> getMemberProfile(Member member) {
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(MemberResponseDto.of(member));
+    }
 }


### PR DESCRIPTION
## 📄 프로필 수정/조회 기능 구현
- 회원의 프로필 수정 및 조회 기능을 구현함.

## 📌 변경 사항
- 회원의 프로필(닉네임, 프로필 이미지)를 수정하는 기능을 구현
- 회원의 프로필 정보를 조회하는 기능을 구현
 

## 🔍 주요 변경 파일 및 내용
- [x] `MemberService`: 수정할 닉네임, 프로필 이미지 url을 전달받아 회원 정보를 수정하도록 코드 구현.
- [x] `MemberController` : 프로필 수정,조회 기능 uri.
- [x] `Member` : 회원의 닉네임과 프로필 이미지 url을 각각 업데이트하도록 메소드 작성.

## ✅ 체크리스트
PR 제출 전 확인해야 할 사항:
- [x] 코드가 올바르게 동작하는지 확인
- [x] 테스트 코드 추가 및 정상 동작 확인
- [x] 문서 업데이트 여부 확인 (README, 위키 등)
- [x] 리뷰어에게 전달할 추가 정보 작성


## 📎 참고 자료
- 없음!
