### PR TITLE
feat : 신규 실명/익명 채팅 참여 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -74,3 +74,12 @@ bootRun {
 jar {
 	enabled = false
 }
+
+/*
+tasks.withType(JavaCompile).configureEach {
+	options.compilerArgs.add("-parameters")
+}
+
+ */
+
+compileJava {    options.compilerArgs << '-parameters'}

--- a/src/main/java/ewha/capston/cockChat/domain/chat/controller/ChatRoomController.java
+++ b/src/main/java/ewha/capston/cockChat/domain/chat/controller/ChatRoomController.java
@@ -29,7 +29,6 @@ public class ChatRoomController {
         return chatService.createChatRoom(requestDto, member);
     }
 
-
     /* mongoDB 테스트 */
     @PostMapping("/chat/test")
     public ResponseEntity testMongo(){
@@ -37,6 +36,4 @@ public class ChatRoomController {
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body("성공");
     }
-
-
 }

--- a/src/main/java/ewha/capston/cockChat/domain/chat/repository/ParticipantRepository.java
+++ b/src/main/java/ewha/capston/cockChat/domain/chat/repository/ParticipantRepository.java
@@ -1,9 +1,0 @@
-package ewha.capston.cockChat.domain.chat.repository;
-
-import ewha.capston.cockChat.domain.chat.domain.Participant;
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
-
-//@Repository
-public interface ParticipantRepository extends JpaRepository<Participant, Long> {
-}

--- a/src/main/java/ewha/capston/cockChat/domain/chat/service/ChatService.java
+++ b/src/main/java/ewha/capston/cockChat/domain/chat/service/ChatService.java
@@ -3,16 +3,14 @@ package ewha.capston.cockChat.domain.chat.service;
 import ewha.capston.cockChat.domain.chat.domain.Chat;
 import ewha.capston.cockChat.domain.chat.domain.ChatRoom;
 import ewha.capston.cockChat.domain.chat.domain.MessageType;
-import ewha.capston.cockChat.domain.chat.domain.Participant;
 import ewha.capston.cockChat.domain.chat.dto.ChatMessageRequestDto;
-import ewha.capston.cockChat.domain.chat.dto.ChatResponseDto;
 import ewha.capston.cockChat.domain.chat.dto.ChatRoomRequestDto;
 import ewha.capston.cockChat.domain.chat.dto.ChatRoomResponseDto;
 import ewha.capston.cockChat.domain.chat.mongo.MongoChatRepository;
 import ewha.capston.cockChat.domain.chat.repository.ChatRoomRepository;
-import ewha.capston.cockChat.domain.chat.repository.ParticipantRepository;
 import ewha.capston.cockChat.domain.member.domain.Member;
-import ewha.capston.cockChat.domain.member.service.MemberService;
+import ewha.capston.cockChat.domain.participant.domain.Participant;
+import ewha.capston.cockChat.domain.participant.repository.ParticipantRepository;
 import ewha.capston.cockChat.global.exception.CustomException;
 import ewha.capston.cockChat.global.exception.ErrorCode;
 import jakarta.transaction.Transactional;
@@ -68,8 +66,9 @@ public class ChatService {
         Participant participant = participantRepository.save(Participant.builder()
                         .chatRoom(chatRoom)
                         .member(member)
-                        .role(Boolean.FALSE)
+                        .isOwner(Boolean.TRUE)
                         .roomNickname(roomNickname)
+                        .participantImgUrl(member.getProfileImgUrl())
                         .build()
         );
 

--- a/src/main/java/ewha/capston/cockChat/domain/member/service/JwtTokenProvider.java
+++ b/src/main/java/ewha/capston/cockChat/domain/member/service/JwtTokenProvider.java
@@ -69,10 +69,19 @@ public class JwtTokenProvider {
             Member member = memberRepository.findByEmail(email).orElseThrow(() -> new CustomException(ErrorCode.NO_MEMBER_EXIST));
             return new UsernamePasswordAuthenticationToken(member, "");
         }catch (ExpiredJwtException e) {
+            log.info(ErrorCode.INVALID_TOKEN.getMessage());
+            log.info("받은 토큰: " + token);
+
             throw new CustomException(ErrorCode.EXPIRED_TOKEN);
         } catch (JwtException e) {
+            log.info(ErrorCode.INVALID_TOKEN.getMessage());
+            log.info("받은 토큰: " + token);
+
             throw new CustomException(ErrorCode.INVALID_TOKEN);
         } catch (IllegalArgumentException e) {
+            log.info(ErrorCode.INVALID_TOKEN.getMessage());
+            log.info("받은 토큰: " + token);
+
             throw new CustomException(ErrorCode.NON_LOGIN);
         }
     }
@@ -89,10 +98,16 @@ public class JwtTokenProvider {
             return !claims.getBody().getExpiration().before(new Date());
         } catch (ExpiredJwtException e){
             log.info(ErrorCode.EXPIRED_TOKEN.getMessage());
+            log.info("받은 토큰: " + jwtToken);
+
         } catch (JwtException e){
             log.info(ErrorCode.INVALID_TOKEN.getMessage());
+            log.info("받은 토큰: " + jwtToken);
+
         } catch (IllegalArgumentException e){
             log.info(ErrorCode.NON_LOGIN.getMessage());
+            log.info("받은 토큰: " + jwtToken);
+
         }
         return false;
     }

--- a/src/main/java/ewha/capston/cockChat/domain/participant/controller/ParticipantController.java
+++ b/src/main/java/ewha/capston/cockChat/domain/participant/controller/ParticipantController.java
@@ -1,0 +1,30 @@
+package ewha.capston.cockChat.domain.participant.controller;
+
+import ewha.capston.cockChat.domain.member.domain.Member;
+import ewha.capston.cockChat.domain.participant.dto.ParticipantRequestDto;
+import ewha.capston.cockChat.domain.participant.dto.ParticipantResponseDto;
+import ewha.capston.cockChat.domain.participant.service.ParticipantService;
+import ewha.capston.cockChat.global.config.auth.AuthUser;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/chatRooms")
+public class ParticipantController {
+
+    private final ParticipantService participantService;
+
+    /* 신규 실명 채팅방 입장 */
+    @PostMapping("/{chatRoomId}/participants/real")
+    public ResponseEntity<ParticipantResponseDto> joinRealNameChatroom(@AuthUser Member member,  @PathVariable Long chatRoomId){
+        return participantService.joinRealNameChatroom(member,chatRoomId);
+    }
+
+    /* 신규 익명 채팅방 입장 */
+    @PostMapping("/{chatRoomId}/participants/anonymous")
+    public ResponseEntity<ParticipantResponseDto> joinAnonymousChatroom(@AuthUser Member member, @PathVariable Long chatRoomId, @RequestBody ParticipantRequestDto requestDto){
+        return participantService.joinAnonymousChatroom(member,chatRoomId,requestDto);
+    }
+}

--- a/src/main/java/ewha/capston/cockChat/domain/participant/domain/Participant.java
+++ b/src/main/java/ewha/capston/cockChat/domain/participant/domain/Participant.java
@@ -1,4 +1,4 @@
-package ewha.capston.cockChat.domain.chat.domain;
+package ewha.capston.cockChat.domain.participant.domain;
 
 import ewha.capston.cockChat.domain.chat.domain.ChatRoom;
 import ewha.capston.cockChat.domain.member.domain.Member;
@@ -12,21 +12,14 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Participant {
+
     @Id
     @Column
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long participantId;
 
-    @ManyToOne
-    @JoinColumn(name = "room_id", nullable = false)
-    private ChatRoom chatRoom;
-
-    @ManyToOne
-    @JoinColumn(name = "member_id", nullable = false)
-    private Member member;
-
-    @Column(nullable = false)
-    private Boolean role;
+    @Column
+    private Boolean isOwner;
 
     @Column
     private String positiveKeywords;
@@ -37,13 +30,24 @@ public class Participant {
     @Column
     private String roomNickname;
 
+    @Column
+    private String participantImgUrl;
+
+    @ManyToOne
+    @JoinColumn(name = "chatRoom_id")
+    private ChatRoom chatRoom;
+
+    @ManyToOne
+    @JoinColumn(name = "member_id")
+    private Member member;
 
     @Builder
-    public Participant(ChatRoom chatRoom, Member member, Boolean role, String roomNickname){
+    public Participant(Boolean isOwner, String roomNickname, String participantImgUrl, ChatRoom chatRoom, Member member){
+        this.isOwner = isOwner;
+        this.roomNickname = roomNickname;
+        this.participantImgUrl = participantImgUrl;
         this.chatRoom = chatRoom;
         this.member = member;
-        this.role = role;
-        this.roomNickname = roomNickname;
     }
 
 

--- a/src/main/java/ewha/capston/cockChat/domain/participant/dto/ParticipantRequestDto.java
+++ b/src/main/java/ewha/capston/cockChat/domain/participant/dto/ParticipantRequestDto.java
@@ -1,0 +1,11 @@
+package ewha.capston.cockChat.domain.participant.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class ParticipantRequestDto {
+    private String roomNickname;
+    private String participantImgUrl;
+}

--- a/src/main/java/ewha/capston/cockChat/domain/participant/dto/ParticipantResponseDto.java
+++ b/src/main/java/ewha/capston/cockChat/domain/participant/dto/ParticipantResponseDto.java
@@ -1,0 +1,28 @@
+package ewha.capston.cockChat.domain.participant.dto;
+
+import ewha.capston.cockChat.domain.participant.domain.Participant;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+public class ParticipantResponseDto {
+    private Long participantId;
+    private String roomNickname;
+    private Long roomId;
+    private Boolean isOwner;
+    private String participantImgUrl;
+
+    public static ParticipantResponseDto of(Participant participant){
+        return ParticipantResponseDto.builder()
+                .participantId(participant.getParticipantId())
+                .roomNickname(participant.getRoomNickname())
+                .roomId(participant.getChatRoom().getRoomId())
+                .isOwner(participant.getIsOwner())
+                .participantImgUrl(participant.getParticipantImgUrl())
+                .build();
+    }
+}

--- a/src/main/java/ewha/capston/cockChat/domain/participant/repository/ParticipantRepository.java
+++ b/src/main/java/ewha/capston/cockChat/domain/participant/repository/ParticipantRepository.java
@@ -1,0 +1,10 @@
+package ewha.capston.cockChat.domain.participant.repository;
+
+import ewha.capston.cockChat.domain.chat.domain.ChatRoom;
+import ewha.capston.cockChat.domain.member.domain.Member;
+import ewha.capston.cockChat.domain.participant.domain.Participant;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ParticipantRepository extends JpaRepository<Participant, Long> {
+    Boolean existsByChatRoomAndMember(ChatRoom chatRoom, Member member);
+}

--- a/src/main/java/ewha/capston/cockChat/domain/participant/service/ParticipantService.java
+++ b/src/main/java/ewha/capston/cockChat/domain/participant/service/ParticipantService.java
@@ -1,0 +1,68 @@
+package ewha.capston.cockChat.domain.participant.service;
+
+import ewha.capston.cockChat.domain.chat.domain.ChatRoom;
+import ewha.capston.cockChat.domain.chat.repository.ChatRoomRepository;
+import ewha.capston.cockChat.domain.member.domain.Member;
+import ewha.capston.cockChat.domain.participant.domain.Participant;
+import ewha.capston.cockChat.domain.participant.dto.ParticipantRequestDto;
+import ewha.capston.cockChat.domain.participant.dto.ParticipantResponseDto;
+import ewha.capston.cockChat.domain.participant.repository.ParticipantRepository;
+import ewha.capston.cockChat.global.exception.CustomException;
+import ewha.capston.cockChat.global.exception.ErrorCode;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class ParticipantService {
+
+    private final ChatRoomRepository chatRoomRepository;
+    private final ParticipantRepository participantRepository;
+
+    /* 실명 채팅방 신규 입장 */
+    public ResponseEntity<ParticipantResponseDto> joinRealNameChatroom(Member member, Long chatRoomId) {
+        ChatRoom chatRoom = chatRoomRepository.findById(chatRoomId)
+                .orElseThrow(()->new CustomException(ErrorCode.INVALID_ROOM));
+        if(participantRepository.existsByChatRoomAndMember(chatRoom,member).equals(Boolean.TRUE))
+            throw new CustomException(ErrorCode.ALREADY_JOINED_MEMBER);
+
+        Participant participant = participantRepository.save(
+                Participant.builder()
+                        .isOwner(false)
+                        .roomNickname(member.getNickname())
+                        .participantImgUrl(member.getProfileImgUrl())
+                        .chatRoom(chatRoom)
+                        .member(member)
+                        .build()
+        );
+
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ParticipantResponseDto.of(participant));
+
+    }
+
+    /* 익명 채팅방 신규 입장 */
+    public ResponseEntity<ParticipantResponseDto> joinAnonymousChatroom(Member member, Long chatRoomId, ParticipantRequestDto requestDto) {
+        ChatRoom chatRoom = chatRoomRepository.findById(chatRoomId)
+                .orElseThrow(()->new CustomException(ErrorCode.INVALID_ROOM));
+        if(participantRepository.existsByChatRoomAndMember(chatRoom,member).equals(Boolean.TRUE))
+            throw new CustomException(ErrorCode.ALREADY_JOINED_MEMBER);
+
+        Participant participant = participantRepository.save(
+                Participant.builder()
+                        .isOwner(false)
+                        .roomNickname(requestDto.getRoomNickname())
+                        .participantImgUrl(requestDto.getParticipantImgUrl())
+                        .chatRoom(chatRoom)
+                        .member(member)
+                        .build()
+        );
+
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ParticipantResponseDto.of(participant));
+    }
+}

--- a/src/main/java/ewha/capston/cockChat/global/exception/ErrorCode.java
+++ b/src/main/java/ewha/capston/cockChat/global/exception/ErrorCode.java
@@ -11,12 +11,13 @@ public enum ErrorCode {
 
     /* member */
     NO_MEMBER_EXIST(HttpStatus.BAD_REQUEST , "가입되지 않은 회원입니다."),
-    ALREADY_LIKED(HttpStatus.BAD_REQUEST,"이미 좋아요를 누른 스크랩입니다."),
     EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED,"만료된 토큰입니다." ),
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED,"유효하지 않은 토큰입니다." ),
     NON_LOGIN(HttpStatus.BAD_REQUEST,"로그인이 필요합니다." ),
     INVALID_MEMBER(HttpStatus.BAD_REQUEST,"접근 권한이 없는 회원입니다."),
     ALREADY_EXIST_NICKNAME(HttpStatus.BAD_REQUEST, "이미 존재하는 닉네임입니다."),
+    ALREADY_JOINED_MEMBER(HttpStatus.BAD_REQUEST,"이미 등록된 회원입니다."),
+
 
     /* chat room*/
     INVALID_ROOM(HttpStatus.BAD_REQUEST, "존재하지 않는 채팅방입니다."),


### PR DESCRIPTION
## 📄 feat : 신규 실명/익명 채팅 참여 기능 구현
- participant(채팅 참가자) 컬럼 수정
- 구글 로그인 설정 수정
- 신규 실명/익명 채팅 참여 기능 구현

## 📌 변경 사항
- participant 기존 chat 디렉토리에서 participant 디렉토리로 분리함.
  - 해당 디렉토리 내에서 controller, repository 등의 코드 작성.


## 🔍 주요 변경 파일 및 내용
- [x] `JwtTokenProvider`:  검증 단계에서 토큰 출력하는 로그를 추가함.
- [x] `Participant` : 채팅방 소유자임을 의미하는  기존 컬럼 `role` 을  `isOwner`로 변경하여 의미를 명시적으로 표현하도록 수정함. 또한 프로필 url 컬럼 추가함.
- [x] `ParticipantController` : 실명/익명 채팅 신규 등록 코드 작성
- [x] `ParticipantService` : 실명/익명 채팅 신규 등록 코드 작성
- [x] `ErrorCode` : participant 관련하여 이미 채팅방에 들어와있을 때 다시 등록하려는 경우 발생시킬 에러를 추가 작성함.

## ✅ 체크리스트
PR 제출 전 확인해야 할 사항:
- [x] 코드가 올바르게 동작하는지 확인
- [x] 테스트 코드 추가 및 정상 동작 확인
- [x] 문서 업데이트 여부 확인 (README, 위키 등)
- [x] 리뷰어에게 전달할 추가 정보 작성


## 📎 참고 자료
- 컴파일 관련 설정 변경 후 인텔리제이 `out` 폴더를 삭제한 후 실행해야 변경한 설정이 반영됨.
  - https://lala9663.tistory.com/166
