### PR TITLE
feat : 채팅방 생성, 고유 코드로 채팅방 조회

### DIFF
--- a/src/main/java/ewha/capston/cockChat/domain/chat/controller/ChatRoomController.java
+++ b/src/main/java/ewha/capston/cockChat/domain/chat/controller/ChatRoomController.java
@@ -23,7 +23,7 @@ public class ChatRoomController {
 
     /* 채팅방 생성 */
     // 이후  @AuthUser 추가하기
-    @PostMapping("/chatroom")
+    @PostMapping("/chatRoom")
     public ResponseEntity<ChatRoomResponseDto> createChatRoom(@RequestBody ChatRoomRequestDto requestDto){
         Member member = memberService.findMemberByEmail("ahtnwl1004@ewhain.net");
         return chatService.createChatRoom(requestDto, member);

--- a/src/main/java/ewha/capston/cockChat/domain/chat/controller/ChatRoomController.java
+++ b/src/main/java/ewha/capston/cockChat/domain/chat/controller/ChatRoomController.java
@@ -9,10 +9,7 @@ import ewha.capston.cockChat.global.config.auth.AuthUser;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -24,9 +21,15 @@ public class ChatRoomController {
 
     /* 채팅방 생성 */
     // 이후  @AuthUser 추가하기
-    @PostMapping("/chatRoom")
+    @PostMapping("/chatRooms")
     public ResponseEntity<ChatRoomResponseDto> createChatRoom( @AuthUser Member member, @RequestBody ChatRoomRequestDto requestDto){
         return chatService.createChatRoom(requestDto, member);
+    }
+
+    /* 고유 코드로 채팅방 조회 */
+    @GetMapping("/chatRooms/{code}")
+    public ResponseEntity<ChatRoomResponseDto> getChatRoomByIdentifier(@AuthUser Member member, @PathVariable String code){
+        return chatService.getChatRoomByIdentifier(member,code);
     }
 
     /* mongoDB 테스트 */

--- a/src/main/java/ewha/capston/cockChat/domain/chat/controller/ChatRoomController.java
+++ b/src/main/java/ewha/capston/cockChat/domain/chat/controller/ChatRoomController.java
@@ -2,6 +2,7 @@ package ewha.capston.cockChat.domain.chat.controller;
 
 import ewha.capston.cockChat.domain.chat.dto.ChatRoomRequestDto;
 import ewha.capston.cockChat.domain.chat.dto.ChatRoomResponseDto;
+import ewha.capston.cockChat.domain.chat.service.ChatRoomService;
 import ewha.capston.cockChat.domain.chat.service.ChatService;
 import ewha.capston.cockChat.domain.member.domain.Member;
 import ewha.capston.cockChat.domain.member.service.MemberService;
@@ -18,18 +19,19 @@ public class ChatRoomController {
 
     private final ChatService chatService;
     private final MemberService memberService;
+    private final ChatRoomService chatRoomService;
 
     /* 채팅방 생성 */
     // 이후  @AuthUser 추가하기
     @PostMapping("/chatRooms")
     public ResponseEntity<ChatRoomResponseDto> createChatRoom( @AuthUser Member member, @RequestBody ChatRoomRequestDto requestDto){
-        return chatService.createChatRoom(requestDto, member);
+        return chatRoomService.createChatRoom(requestDto, member);
     }
 
     /* 고유 코드로 채팅방 조회 */
     @GetMapping("/chatRooms/{code}")
     public ResponseEntity<ChatRoomResponseDto> getChatRoomByIdentifier(@AuthUser Member member, @PathVariable String code){
-        return chatService.getChatRoomByIdentifier(member,code);
+        return chatRoomService.getChatRoomByIdentifier(member,code);
     }
 
     /* mongoDB 테스트 */

--- a/src/main/java/ewha/capston/cockChat/domain/chat/controller/ChatRoomController.java
+++ b/src/main/java/ewha/capston/cockChat/domain/chat/controller/ChatRoomController.java
@@ -5,6 +5,7 @@ import ewha.capston.cockChat.domain.chat.dto.ChatRoomResponseDto;
 import ewha.capston.cockChat.domain.chat.service.ChatService;
 import ewha.capston.cockChat.domain.member.domain.Member;
 import ewha.capston.cockChat.domain.member.service.MemberService;
+import ewha.capston.cockChat.global.config.auth.AuthUser;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -24,8 +25,7 @@ public class ChatRoomController {
     /* 채팅방 생성 */
     // 이후  @AuthUser 추가하기
     @PostMapping("/chatRoom")
-    public ResponseEntity<ChatRoomResponseDto> createChatRoom(@RequestBody ChatRoomRequestDto requestDto){
-        Member member = memberService.findMemberByEmail("ahtnwl1004@ewhain.net");
+    public ResponseEntity<ChatRoomResponseDto> createChatRoom( @AuthUser Member member, @RequestBody ChatRoomRequestDto requestDto){
         return chatService.createChatRoom(requestDto, member);
     }
 

--- a/src/main/java/ewha/capston/cockChat/domain/chat/domain/ChatRoom.java
+++ b/src/main/java/ewha/capston/cockChat/domain/chat/domain/ChatRoom.java
@@ -31,13 +31,17 @@ public class ChatRoom {
     @Column(nullable = false)
     private Boolean nicknameType;
 
+    @Column
+    private String chatRoomImgUrl;
+
     @Builder
-    public ChatRoom(String identifier, Boolean roomType, Long password, String roomName, Boolean nicknameType){
+    public ChatRoom(String identifier, Boolean roomType, Long password, String roomName, Boolean nicknameType, String chatRoomImgUrl){
         this.identifier = identifier;
         this.roomType = roomType;
         this.password = password;
         this.roomName = roomName;
         this.nicknameType = nicknameType;
+        this.chatRoomImgUrl = chatRoomImgUrl;
     }
 
 

--- a/src/main/java/ewha/capston/cockChat/domain/chat/dto/ChatRoomRequestDto.java
+++ b/src/main/java/ewha/capston/cockChat/domain/chat/dto/ChatRoomRequestDto.java
@@ -12,4 +12,5 @@ public class ChatRoomRequestDto {
     private Boolean roomType;
     private Long password;
     private Boolean nicknameType;
+    private String chatRoomImgUrl;
 }

--- a/src/main/java/ewha/capston/cockChat/domain/chat/dto/ChatRoomResponseDto.java
+++ b/src/main/java/ewha/capston/cockChat/domain/chat/dto/ChatRoomResponseDto.java
@@ -18,6 +18,7 @@ public class ChatRoomResponseDto {
     private Boolean roomType;
     private Long password;
     private Boolean nicknameType;
+    private String chatRoomImgUrl;
 
     public static ChatRoomResponseDto of(ChatRoom chatRoom){
         return ChatRoomResponseDto.builder()
@@ -28,8 +29,7 @@ public class ChatRoomResponseDto {
                 .roomType(chatRoom.getRoomType())
                 .password(chatRoom.getPassword())
                 .nicknameType(chatRoom.getNicknameType())
+                .chatRoomImgUrl(chatRoom.getChatRoomImgUrl())
                 .build();
     }
-
-
 }

--- a/src/main/java/ewha/capston/cockChat/domain/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/ewha/capston/cockChat/domain/chat/repository/ChatRoomRepository.java
@@ -4,9 +4,12 @@ import ewha.capston.cockChat.domain.chat.domain.ChatRoom;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 //@Repository
 public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
     Boolean existsByIdentifier(String identifier);
 
+    Optional<ChatRoom> findByIdentifier(String code);
 }
 

--- a/src/main/java/ewha/capston/cockChat/domain/chat/service/ChatRoomService.java
+++ b/src/main/java/ewha/capston/cockChat/domain/chat/service/ChatRoomService.java
@@ -1,0 +1,93 @@
+package ewha.capston.cockChat.domain.chat.service;
+
+import ewha.capston.cockChat.domain.chat.domain.ChatRoom;
+import ewha.capston.cockChat.domain.chat.dto.ChatRoomRequestDto;
+import ewha.capston.cockChat.domain.chat.dto.ChatRoomResponseDto;
+import ewha.capston.cockChat.domain.chat.repository.ChatRoomRepository;
+import ewha.capston.cockChat.domain.member.domain.Member;
+import ewha.capston.cockChat.domain.participant.repository.ParticipantRepository;
+import ewha.capston.cockChat.global.exception.CustomException;
+import ewha.capston.cockChat.global.exception.ErrorCode;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+
+import java.security.SecureRandom;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class ChatRoomService {
+
+    private final ChatRoomRepository chatRoomRepository;
+    private final ParticipantRepository participantRepository;
+
+
+    /* 체팅방 생성 */
+    public ResponseEntity<ChatRoomResponseDto> createChatRoom(ChatRoomRequestDto requestDto, Member member) {
+
+        /* 6자리의 랜덤 문자열 생성 : 중복 없도록 생성 */
+        String identifier = null;
+        while(Boolean.TRUE){
+            identifier = generateRandomMixStr(6,true);
+            if(chatRoomRepository.existsByIdentifier(identifier) == Boolean.FALSE) break;
+        }
+
+        /* 채팅방 생성 */
+        ChatRoom chatRoom = chatRoomRepository.save(ChatRoom.builder()
+                .roomName(requestDto.getRoomName())
+                .roomType(requestDto.getRoomType())
+                .nicknameType(requestDto.getNicknameType())
+                .password(requestDto.getPassword())
+                .identifier(identifier)
+                .chatRoomImgUrl(requestDto.getChatRoomImgUrl())
+                .build());
+
+
+        /* 채팅방 생성인을 participant 로 채팅방에 참가. <- 이 부분 우선 주석 처리 */
+        /*
+        String roomNickname = "별명";
+        if(chatRoom.getNicknameType() == Boolean.FALSE) roomNickname = ; // 별명 사용 채팅방인 경우
+        else roomNickname = member.getNickname(); // 실명 사용 채팅방인 경우
+        Participant participant = participantRepository.save(Participant.builder()
+                        .chatRoom(chatRoom)
+                        .member(member)
+                        .isOwner(Boolean.TRUE)
+                        .roomNickname(roomNickname)
+                        .participantImgUrl(member.getProfileImgUrl())
+                        .build()
+        );
+         */
+
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ChatRoomResponseDto.of(chatRoom));
+    }
+
+
+    /* 채팅방 고유 코드로 채팅방 조회 */
+    public ResponseEntity<ChatRoomResponseDto> getChatRoomByIdentifier(Member member, String code) {
+        ChatRoom chatRoom = chatRoomRepository.findByIdentifier(code)
+                .orElseThrow(()->new CustomException(ErrorCode.INVALID_ROOM));
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(ChatRoomResponseDto.of(chatRoom));
+    }
+
+
+
+    /* 랜덤 문자열 생성 */
+    public  String generateRandomMixStr(int length, boolean isUpperCase) {
+        String characters = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+
+        SecureRandom random = new SecureRandom();
+        StringBuilder sb = new StringBuilder(length);
+
+        for (int i = 0; i < length; i++) {
+            int index = random.nextInt(characters.length());
+            sb.append(characters.charAt(index));
+        }
+        return isUpperCase ? sb.toString() : sb.toString().toLowerCase();
+    }
+
+}

--- a/src/main/java/ewha/capston/cockChat/domain/chat/service/ChatService.java
+++ b/src/main/java/ewha/capston/cockChat/domain/chat/service/ChatService.java
@@ -80,6 +80,14 @@ public class ChatService {
                 .body(ChatRoomResponseDto.of(chatRoom));
     }
 
+    /* 채팅방 고유 코드로 채팅방 조회 */
+    public ResponseEntity<ChatRoomResponseDto> getChatRoomByIdentifier(Member member, String code) {
+        ChatRoom chatRoom = chatRoomRepository.findByIdentifier(code)
+                .orElseThrow(()->new CustomException(ErrorCode.INVALID_ROOM));
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(ChatRoomResponseDto.of(chatRoom));
+    }
+
     /* 메시지 보내기 */
     public void sendMessage(Long roomId, ChatMessageRequestDto requestDto) {
 
@@ -122,5 +130,4 @@ public class ChatService {
         }
         return isUpperCase ? sb.toString() : sb.toString().toLowerCase();
     }
-
 }

--- a/src/main/java/ewha/capston/cockChat/domain/chat/service/ChatService.java
+++ b/src/main/java/ewha/capston/cockChat/domain/chat/service/ChatService.java
@@ -40,53 +40,6 @@ public class ChatService {
         mongoChatRepository.save(chat);
     }
 
-    /* 체팅방 생성 */
-    public ResponseEntity<ChatRoomResponseDto> createChatRoom(ChatRoomRequestDto requestDto, Member member) {
-
-        /* 6자리의 랜덤 문자열 생성 : 중복 없도록 생성 */
-        String identifier = null;
-        while(Boolean.TRUE){
-            identifier = generateRandomMixStr(6,true);
-            if(chatRoomRepository.existsByIdentifier(identifier) == Boolean.FALSE) break;
-        }
-
-        /* 채팅방 생성 */
-        ChatRoom chatRoom = chatRoomRepository.save(ChatRoom.builder()
-                .roomName(requestDto.getRoomName())
-                .roomType(requestDto.getRoomType())
-                .nicknameType(requestDto.getNicknameType())
-                .password(requestDto.getPassword())
-                .identifier(identifier)
-                .chatRoomImgUrl(requestDto.getChatRoomImgUrl())
-                .build());
-
-
-        /* 채팅방 생성인을 participant 로 채팅방에 참가. <- 이 부분 우선 주석 처리 */
-        /*
-        String roomNickname = "별명";
-        if(chatRoom.getNicknameType() == Boolean.FALSE) roomNickname = ; // 별명 사용 채팅방인 경우
-        else roomNickname = member.getNickname(); // 실명 사용 채팅방인 경우
-        Participant participant = participantRepository.save(Participant.builder()
-                        .chatRoom(chatRoom)
-                        .member(member)
-                        .isOwner(Boolean.TRUE)
-                        .roomNickname(roomNickname)
-                        .participantImgUrl(member.getProfileImgUrl())
-                        .build()
-        );
-         */
-
-        return ResponseEntity.status(HttpStatus.CREATED)
-                .body(ChatRoomResponseDto.of(chatRoom));
-    }
-
-    /* 채팅방 고유 코드로 채팅방 조회 */
-    public ResponseEntity<ChatRoomResponseDto> getChatRoomByIdentifier(Member member, String code) {
-        ChatRoom chatRoom = chatRoomRepository.findByIdentifier(code)
-                .orElseThrow(()->new CustomException(ErrorCode.INVALID_ROOM));
-        return ResponseEntity.status(HttpStatus.OK)
-                .body(ChatRoomResponseDto.of(chatRoom));
-    }
 
     /* 메시지 보내기 */
     public void sendMessage(Long roomId, ChatMessageRequestDto requestDto) {
@@ -115,19 +68,4 @@ public class ChatService {
         messagingTemplate.convertAndSend("/topic/public/" + roomId, chat);
     }
 
-
-
-    /* 랜덤 문자열 생성 */
-    public  String generateRandomMixStr(int length, boolean isUpperCase) {
-        String characters = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
-
-        SecureRandom random = new SecureRandom();
-        StringBuilder sb = new StringBuilder(length);
-
-        for (int i = 0; i < length; i++) {
-            int index = random.nextInt(characters.length());
-            sb.append(characters.charAt(index));
-        }
-        return isUpperCase ? sb.toString() : sb.toString().toLowerCase();
-    }
 }

--- a/src/main/java/ewha/capston/cockChat/domain/chat/service/ChatService.java
+++ b/src/main/java/ewha/capston/cockChat/domain/chat/service/ChatService.java
@@ -57,11 +57,14 @@ public class ChatService {
                 .nicknameType(requestDto.getNicknameType())
                 .password(requestDto.getPassword())
                 .identifier(identifier)
+                .chatRoomImgUrl(requestDto.getChatRoomImgUrl())
                 .build());
 
-        /* 채팅방 생성인을 participant 로 채팅방에 참가.*/
+
+        /* 채팅방 생성인을 participant 로 채팅방에 참가. <- 이 부분 우선 주석 처리 */
+        /*
         String roomNickname = "별명";
-        if(chatRoom.getNicknameType() == Boolean.FALSE) roomNickname = "별명"; // 별명 사용 채팅방인 경우
+        if(chatRoom.getNicknameType() == Boolean.FALSE) roomNickname = ; // 별명 사용 채팅방인 경우
         else roomNickname = member.getNickname(); // 실명 사용 채팅방인 경우
         Participant participant = participantRepository.save(Participant.builder()
                         .chatRoom(chatRoom)
@@ -71,6 +74,7 @@ public class ChatService {
                         .participantImgUrl(member.getProfileImgUrl())
                         .build()
         );
+         */
 
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(ChatRoomResponseDto.of(chatRoom));

--- a/src/main/java/ewha/capston/cockChat/domain/participant/domain/Participant.java
+++ b/src/main/java/ewha/capston/cockChat/domain/participant/domain/Participant.java
@@ -50,5 +50,4 @@ public class Participant {
         this.member = member;
     }
 
-
 }


### PR DESCRIPTION
## 📄 feat : 채팅방 생성, 고유 코드로 채팅방 조회
- 채팅방 생성 기능 수정
- 고유 코드로 채팅방 1개 조회 기능 구현
- 파일 구조 수정(파일 분리)

## 📌 변경 사항
- 채팅방 생성 시 채팅방의 대표 이미지 url을 전달받아 저장될 수 있도록 수정함.
- 채팅방 생성 시 기존에 생성자를 `participant` 로 추가하는 부분을 주석처리함.
- 채팅방 생성 시 부여받는 고유 코드를 통해 채팅방 1개를 조회하는 기능을 구현함.

## 🔍 주요 변경 파일 및 내용
- [ ] `chatRoomService.java` & `chatService.java` : 기존에 채팅방 관련 코드와 채팅 관련 코드가 모두 `chatService.java` 에 작성되어 있었지만 채팅방 관련 코드를 `chatRoomService.java` 파일에 옮김.
- [ ] `chatRoomDto.java` : `chatRoom` 관련 `dto` 파일에 채팅방의 대표 이미지를 전달할 `chatRoomImgUrl` 필드를 추가함.
- [ ] `chatRoomController.java` : uri 경로를 `/chatRooms` 로 통일함.

## ✅ 체크리스트
PR 제출 전 확인해야 할 사항:
- [ ] 코드가 올바르게 동작하는지 확인
- [ ] 테스트 코드 추가 및 정상 동작 확인
- [ ] 문서 업데이트 여부 확인 (README, 위키 등)
- [ ] 리뷰어에게 전달할 추가 정보 작성


## 📎 참고 자료
- 없어요!
  
