### PR TITLE
feat : 익명 프로필 목록 조회 기능

### DIFF
--- a/src/main/java/ewha/capston/cockChat/domain/chat/domain/ChatRoom.java
+++ b/src/main/java/ewha/capston/cockChat/domain/chat/domain/ChatRoom.java
@@ -20,7 +20,7 @@ public class ChatRoom {
     private String identifier;
 
     @Column(nullable = false)
-    private Boolean roomType;
+    private Boolean isSecretChatRoom;
 
     @Column
     private Long password;
@@ -29,18 +29,18 @@ public class ChatRoom {
     private String roomName;
 
     @Column(nullable = false)
-    private Boolean nicknameType;
+    private Boolean isAnonymousChatRoom;
 
     @Column
     private String chatRoomImgUrl;
 
     @Builder
-    public ChatRoom(String identifier, Boolean roomType, Long password, String roomName, Boolean nicknameType, String chatRoomImgUrl){
+    public ChatRoom(String identifier, Boolean isSecretChatRoom, Long password, String roomName, Boolean isAnonymousChatRoom, String chatRoomImgUrl){
         this.identifier = identifier;
-        this.roomType = roomType;
+        this.isSecretChatRoom = isSecretChatRoom;
         this.password = password;
         this.roomName = roomName;
-        this.nicknameType = nicknameType;
+        this.isAnonymousChatRoom = isAnonymousChatRoom;
         this.chatRoomImgUrl = chatRoomImgUrl;
     }
 

--- a/src/main/java/ewha/capston/cockChat/domain/chat/dto/ChatRoomRequestDto.java
+++ b/src/main/java/ewha/capston/cockChat/domain/chat/dto/ChatRoomRequestDto.java
@@ -9,8 +9,8 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ChatRoomRequestDto {
     private String roomName;
-    private Boolean roomType;
+    private Boolean isSecretChatRoom;
     private Long password;
-    private Boolean nicknameType;
+    private Boolean isAnonymousChatRoom;
     private String chatRoomImgUrl;
 }

--- a/src/main/java/ewha/capston/cockChat/domain/chat/dto/ChatRoomResponseDto.java
+++ b/src/main/java/ewha/capston/cockChat/domain/chat/dto/ChatRoomResponseDto.java
@@ -15,9 +15,9 @@ public class ChatRoomResponseDto {
     private String identifier;
     private Long lastChat;
     private String roomName;
-    private Boolean roomType;
+    private Boolean isSecretChatRoom;
     private Long password;
-    private Boolean nicknameType;
+    private Boolean isAnonymousChatRoom;
     private String chatRoomImgUrl;
 
     public static ChatRoomResponseDto of(ChatRoom chatRoom){
@@ -26,9 +26,9 @@ public class ChatRoomResponseDto {
                 .identifier(chatRoom.getIdentifier())
                 .lastChat(0L) // 이후 수정
                 .roomName(chatRoom.getRoomName())
-                .roomType(chatRoom.getRoomType())
+                .isSecretChatRoom(chatRoom.getIsSecretChatRoom())
                 .password(chatRoom.getPassword())
-                .nicknameType(chatRoom.getNicknameType())
+                .isAnonymousChatRoom(chatRoom.getIsAnonymousChatRoom())
                 .chatRoomImgUrl(chatRoom.getChatRoomImgUrl())
                 .build();
     }

--- a/src/main/java/ewha/capston/cockChat/domain/chat/service/ChatRoomService.java
+++ b/src/main/java/ewha/capston/cockChat/domain/chat/service/ChatRoomService.java
@@ -38,28 +38,12 @@ public class ChatRoomService {
         /* 채팅방 생성 */
         ChatRoom chatRoom = chatRoomRepository.save(ChatRoom.builder()
                 .roomName(requestDto.getRoomName())
-                .roomType(requestDto.getRoomType())
-                .nicknameType(requestDto.getNicknameType())
+                .isSecretChatRoom(requestDto.getIsSecretChatRoom())
+                .isAnonymousChatRoom(requestDto.getIsAnonymousChatRoom())
                 .password(requestDto.getPassword())
                 .identifier(identifier)
                 .chatRoomImgUrl(requestDto.getChatRoomImgUrl())
                 .build());
-
-
-        /* 채팅방 생성인을 participant 로 채팅방에 참가. <- 이 부분 우선 주석 처리 */
-        /*
-        String roomNickname = "별명";
-        if(chatRoom.getNicknameType() == Boolean.FALSE) roomNickname = ; // 별명 사용 채팅방인 경우
-        else roomNickname = member.getNickname(); // 실명 사용 채팅방인 경우
-        Participant participant = participantRepository.save(Participant.builder()
-                        .chatRoom(chatRoom)
-                        .member(member)
-                        .isOwner(Boolean.TRUE)
-                        .roomNickname(roomNickname)
-                        .participantImgUrl(member.getProfileImgUrl())
-                        .build()
-        );
-         */
 
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(ChatRoomResponseDto.of(chatRoom));

--- a/src/main/java/ewha/capston/cockChat/domain/member/controller/MemberController.java
+++ b/src/main/java/ewha/capston/cockChat/domain/member/controller/MemberController.java
@@ -7,6 +7,9 @@ import ewha.capston.cockChat.domain.member.service.AuthService;
 import ewha.capston.cockChat.domain.member.service.MemberService;
 import ewha.capston.cockChat.domain.member.dto.request.LoginRequestDto;
 import ewha.capston.cockChat.domain.member.dto.response.LoginResponseDto;
+import ewha.capston.cockChat.domain.participant.dto.ParticipantResponseDto;
+import ewha.capston.cockChat.domain.participant.service.ParticipantService;
+import ewha.capston.cockChat.global.config.auth.AuthUser;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -14,6 +17,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.io.IOException;
+import java.util.List;
 
 @Slf4j
 @RestController
@@ -22,6 +26,7 @@ import java.io.IOException;
 public class MemberController {
 
     private final MemberService memberService;
+    private final ParticipantService participantService;
     private final AuthService authService;
 
     /* 로그인 */
@@ -45,6 +50,11 @@ public class MemberController {
         return memberService.getMemberProfile(member);
     }
 
+    /* 익명 프로필 목록 조회 */
+    @GetMapping("/members/my/anonymous-profile")
+    public ResponseEntity<List<ParticipantResponseDto>> getAnonymousProfileListByMember(@AuthUser Member member){
+        return participantService.getAnonymousProfileListByMember(member);
+    }
 
 
 }

--- a/src/main/java/ewha/capston/cockChat/domain/member/service/MemberService.java
+++ b/src/main/java/ewha/capston/cockChat/domain/member/service/MemberService.java
@@ -6,6 +6,9 @@ import ewha.capston.cockChat.domain.member.domain.Member;
 import ewha.capston.cockChat.domain.member.dto.request.MemberUpdateRequestDto;
 import ewha.capston.cockChat.domain.member.dto.response.MemberResponseDto;
 import ewha.capston.cockChat.domain.member.repository.MemberRepository;
+import ewha.capston.cockChat.domain.participant.domain.Participant;
+import ewha.capston.cockChat.domain.participant.dto.ParticipantResponseDto;
+import ewha.capston.cockChat.domain.participant.repository.ParticipantRepository;
 import ewha.capston.cockChat.global.exception.CustomException;
 import ewha.capston.cockChat.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
@@ -16,11 +19,14 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.RequestBody;
 
+import java.util.List;
+
 @Slf4j
 @Service
 @Transactional
 @RequiredArgsConstructor
 public class MemberService {
+
     private final MemberRepository memberRepository;
 
     /* 멤버 생성 */

--- a/src/main/java/ewha/capston/cockChat/domain/participant/controller/ParticipantController.java
+++ b/src/main/java/ewha/capston/cockChat/domain/participant/controller/ParticipantController.java
@@ -1,7 +1,8 @@
 package ewha.capston.cockChat.domain.participant.controller;
 
 import ewha.capston.cockChat.domain.member.domain.Member;
-import ewha.capston.cockChat.domain.participant.dto.ParticipantRequestDto;
+import ewha.capston.cockChat.domain.participant.dto.ParticipantRealRequestDto;
+import ewha.capston.cockChat.domain.participant.dto.ParticipantAnonymousRequestDto;
 import ewha.capston.cockChat.domain.participant.dto.ParticipantResponseDto;
 import ewha.capston.cockChat.domain.participant.service.ParticipantService;
 import ewha.capston.cockChat.global.config.auth.AuthUser;
@@ -18,13 +19,13 @@ public class ParticipantController {
 
     /* 신규 실명 채팅방 입장 */
     @PostMapping("/{chatRoomId}/participants/real")
-    public ResponseEntity<ParticipantResponseDto> joinRealNameChatroom(@AuthUser Member member,  @PathVariable Long chatRoomId){
-        return participantService.joinRealNameChatroom(member,chatRoomId);
+    public ResponseEntity<ParticipantResponseDto> joinRealNameChatroom(@AuthUser Member member,  @PathVariable Long chatRoomId, @RequestBody ParticipantRealRequestDto requestDto){
+        return participantService.joinRealNameChatroom(member,chatRoomId, requestDto);
     }
 
     /* 신규 익명 채팅방 입장 */
     @PostMapping("/{chatRoomId}/participants/anonymous")
-    public ResponseEntity<ParticipantResponseDto> joinAnonymousChatroom(@AuthUser Member member, @PathVariable Long chatRoomId, @RequestBody ParticipantRequestDto requestDto){
+    public ResponseEntity<ParticipantResponseDto> joinAnonymousChatroom(@AuthUser Member member, @PathVariable Long chatRoomId, @RequestBody ParticipantAnonymousRequestDto requestDto){
         return participantService.joinAnonymousChatroom(member,chatRoomId,requestDto);
     }
 }

--- a/src/main/java/ewha/capston/cockChat/domain/participant/dto/ParticipantAnonymousRequestDto.java
+++ b/src/main/java/ewha/capston/cockChat/domain/participant/dto/ParticipantAnonymousRequestDto.java
@@ -1,0 +1,12 @@
+package ewha.capston.cockChat.domain.participant.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class ParticipantAnonymousRequestDto {
+    private Boolean isOwner;
+    private String roomNickname;
+    private String participantImgUrl;
+}

--- a/src/main/java/ewha/capston/cockChat/domain/participant/dto/ParticipantRealRequestDto.java
+++ b/src/main/java/ewha/capston/cockChat/domain/participant/dto/ParticipantRealRequestDto.java
@@ -5,7 +5,6 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
-public class ParticipantRequestDto {
-    private String roomNickname;
-    private String participantImgUrl;
+public class ParticipantRealRequestDto {
+    private Boolean isOwner;
 }

--- a/src/main/java/ewha/capston/cockChat/domain/participant/service/ParticipantService.java
+++ b/src/main/java/ewha/capston/cockChat/domain/participant/service/ParticipantService.java
@@ -16,6 +16,9 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @Service
 @Transactional
 @RequiredArgsConstructor
@@ -68,5 +71,16 @@ public class ParticipantService {
                 .body(ParticipantResponseDto.of(participant));
     }
 
-
+    /* 회원의 익명 프로필 목록 조회 */
+    public ResponseEntity<List<ParticipantResponseDto>> getAnonymousProfileListByMember(Member member) {
+        List<Participant> participantList = participantRepository.findAllByMember(member);
+        List<ParticipantResponseDto> responseDtoList = new ArrayList<>();
+        for(Participant participant : participantList){
+            if(participant.getChatRoom().getIsAnonymousChatRoom().equals(Boolean.TRUE)){
+                responseDtoList.add(ParticipantResponseDto.of(participant));
+            }
+        }
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(responseDtoList);
+    }
 }

--- a/src/main/java/ewha/capston/cockChat/domain/participant/service/ParticipantService.java
+++ b/src/main/java/ewha/capston/cockChat/domain/participant/service/ParticipantService.java
@@ -4,7 +4,8 @@ import ewha.capston.cockChat.domain.chat.domain.ChatRoom;
 import ewha.capston.cockChat.domain.chat.repository.ChatRoomRepository;
 import ewha.capston.cockChat.domain.member.domain.Member;
 import ewha.capston.cockChat.domain.participant.domain.Participant;
-import ewha.capston.cockChat.domain.participant.dto.ParticipantRequestDto;
+import ewha.capston.cockChat.domain.participant.dto.ParticipantAnonymousRequestDto;
+import ewha.capston.cockChat.domain.participant.dto.ParticipantRealRequestDto;
 import ewha.capston.cockChat.domain.participant.dto.ParticipantResponseDto;
 import ewha.capston.cockChat.domain.participant.repository.ParticipantRepository;
 import ewha.capston.cockChat.global.exception.CustomException;
@@ -24,15 +25,16 @@ public class ParticipantService {
     private final ParticipantRepository participantRepository;
 
     /* 실명 채팅방 신규 입장 */
-    public ResponseEntity<ParticipantResponseDto> joinRealNameChatroom(Member member, Long chatRoomId) {
+    public ResponseEntity<ParticipantResponseDto> joinRealNameChatroom(Member member, Long chatRoomId, ParticipantRealRequestDto requestDto) {
         ChatRoom chatRoom = chatRoomRepository.findById(chatRoomId)
                 .orElseThrow(()->new CustomException(ErrorCode.INVALID_ROOM));
+
         if(participantRepository.existsByChatRoomAndMember(chatRoom,member).equals(Boolean.TRUE))
             throw new CustomException(ErrorCode.ALREADY_JOINED_MEMBER);
 
         Participant participant = participantRepository.save(
                 Participant.builder()
-                        .isOwner(false)
+                        .isOwner(requestDto.getIsOwner())
                         .roomNickname(member.getNickname())
                         .participantImgUrl(member.getProfileImgUrl())
                         .chatRoom(chatRoom)
@@ -46,7 +48,7 @@ public class ParticipantService {
     }
 
     /* 익명 채팅방 신규 입장 */
-    public ResponseEntity<ParticipantResponseDto> joinAnonymousChatroom(Member member, Long chatRoomId, ParticipantRequestDto requestDto) {
+    public ResponseEntity<ParticipantResponseDto> joinAnonymousChatroom(Member member, Long chatRoomId, ParticipantAnonymousRequestDto requestDto) {
         ChatRoom chatRoom = chatRoomRepository.findById(chatRoomId)
                 .orElseThrow(()->new CustomException(ErrorCode.INVALID_ROOM));
         if(participantRepository.existsByChatRoomAndMember(chatRoom,member).equals(Boolean.TRUE))
@@ -54,7 +56,7 @@ public class ParticipantService {
 
         Participant participant = participantRepository.save(
                 Participant.builder()
-                        .isOwner(false)
+                        .isOwner(requestDto.getIsOwner())
                         .roomNickname(requestDto.getRoomNickname())
                         .participantImgUrl(requestDto.getParticipantImgUrl())
                         .chatRoom(chatRoom)


### PR DESCRIPTION
## 📄 feat : 익명 프로필 목록 조회 기능
- 사용자의 익명 프로필 목록 조회 기능 구현

## 📌 변경 사항
- 채팅방 신규 입장 시 회원의 채팅방 내 역할(방장 또는 일반 참여자)를 전달하도록 요청 파라미터 추가.
- 채팅방의 유형 관련한 필드명을 보다 Boolean 명시적으로 수정.
- 사용자의 모든 익명 프로필 목록 조회 기능 구현

## 🔍 주요 변경 파일 및 내용
- [x] `ChatRoom.java` : 필드명 수정
- [x]  `ChatRoomRequestDto.java` : 필드명 수정
- [x]  `ChatRoomResponseDto.java` : 필드명 수정
- [x] `MemberController.java` & `ParticipantService.java` : 익명 프로필 목록 조회 기능 구현
- [x]  `ParticipantRealRequestDto.java` & `ParticipantAnonymousRequestDto.java` : 요청 파라미터 추가

## ✅ 체크리스트
PR 제출 전 확인해야 할 사항:
- [x] 코드가 올바르게 동작하는지 확인
- [x] 테스트 코드 추가 및 정상 동작 확인
- [x] 문서 업데이트 여부 확인 (README, 위키 등)
- [x] 리뷰어에게 전달할 추가 정보 작성


## 📎 참고 자료
- 없어요!
