### PR TITLE
feat : 방장 변경 / 채팅방 조회 / 채팅방 삭제

### DIFF
--- a/src/main/java/ewha/capston/cockChat/domain/chat/controller/ChatRoomController.java
+++ b/src/main/java/ewha/capston/cockChat/domain/chat/controller/ChatRoomController.java
@@ -42,6 +42,12 @@ public class ChatRoomController {
         return chatRoomService.getChatRoomListByRoomName(roomName);
     }
 
+    /* 채팅방 삭제 */
+    @DeleteMapping("/chatRooms/{chatRoomId}")
+    public ResponseEntity<Void> removeChatRoom(@AuthUser Member member, @PathVariable(name = "chatRoomId") Long chatRoomId){
+        return chatRoomService.removeChatRoom(member,chatRoomId);
+    }
+
     /* mongoDB 테스트 */
     @PostMapping("/chat/test")
     public ResponseEntity testMongo(){

--- a/src/main/java/ewha/capston/cockChat/domain/chat/controller/ChatRoomController.java
+++ b/src/main/java/ewha/capston/cockChat/domain/chat/controller/ChatRoomController.java
@@ -12,6 +12,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @RestController
 @RequiredArgsConstructor
 @RequestMapping
@@ -32,6 +34,12 @@ public class ChatRoomController {
     @GetMapping("/chatRooms/{code}")
     public ResponseEntity<ChatRoomResponseDto> getChatRoomByIdentifier(@AuthUser Member member, @PathVariable String code){
         return chatRoomService.getChatRoomByIdentifier(member,code);
+    }
+
+    /* 채팅방 이름으로 채팅방 목록 조회 */
+    @GetMapping("/chatRooms")
+    public ResponseEntity<List<ChatRoomResponseDto>> getChatRoomListByRoomName(@AuthUser Member member, @RequestParam String roomName){
+        return chatRoomService.getChatRoomListByRoomName(roomName);
     }
 
     /* mongoDB 테스트 */

--- a/src/main/java/ewha/capston/cockChat/domain/chat/controller/ChatRoomParticipantController.java
+++ b/src/main/java/ewha/capston/cockChat/domain/chat/controller/ChatRoomParticipantController.java
@@ -5,6 +5,8 @@ import ewha.capston.cockChat.domain.chat.dto.ChatRoomSettingRequestDto;
 import ewha.capston.cockChat.domain.chat.dto.ChatRoomSettingResponseDto;
 import ewha.capston.cockChat.domain.chat.service.ChatRoomParticipantService;
 import ewha.capston.cockChat.domain.member.domain.Member;
+import ewha.capston.cockChat.domain.participant.dto.OwnerRequestDto;
+import ewha.capston.cockChat.domain.participant.dto.ParticipantResponseDto;
 import ewha.capston.cockChat.global.config.auth.AuthUser;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -32,12 +34,17 @@ public class ChatRoomParticipantController {
         return chatRoomParticipantService.updateSettings(member,chatRoomId,requestDto);
     }
 
+    /* 채팅방 방장 변경 */
+    @PutMapping("/{chatRoomId}/owner")
+    public ResponseEntity<ParticipantResponseDto> updateChatRoomOwner(@AuthUser Member member, @PathVariable(name = "chatRoomId") Long chatRoomId, @RequestBody OwnerRequestDto requestDto){
+        return chatRoomParticipantService.updateOwner(member, chatRoomId, requestDto);
+    }
+
 
     /* 채팅방 탈퇴 */
     @DeleteMapping("/{chatRoomId}/participants/me")
     public ResponseEntity<Void> removeParticipantFromChatRoom(@AuthUser Member member, @PathVariable(name = "chatRoomId") Long chatRoomId){
         return chatRoomParticipantService.removeParticipantFromChatRoom(member, chatRoomId);
     }
-
 
 }

--- a/src/main/java/ewha/capston/cockChat/domain/chat/controller/ChatRoomParticipantController.java
+++ b/src/main/java/ewha/capston/cockChat/domain/chat/controller/ChatRoomParticipantController.java
@@ -40,11 +40,16 @@ public class ChatRoomParticipantController {
         return chatRoomParticipantService.updateOwner(member, chatRoomId, requestDto);
     }
 
-
     /* 채팅방 탈퇴 */
     @DeleteMapping("/{chatRoomId}/participants/me")
     public ResponseEntity<Void> removeParticipantFromChatRoom(@AuthUser Member member, @PathVariable(name = "chatRoomId") Long chatRoomId){
         return chatRoomParticipantService.removeParticipantFromChatRoom(member, chatRoomId);
+    }
+
+    /* 방장 권한 참여자 탈퇴 */
+    @DeleteMapping("/{chatRoomId}/participants/{participantId}")
+    public ResponseEntity<Void> removeParticipantByOwner(@AuthUser Member member, @PathVariable(name = "chatRoomId") Long chatRoomId, @PathVariable(name = "participantId") Long participantId){
+        return chatRoomParticipantService.removeParticipantByOwner(member,chatRoomId,participantId);
     }
 
 }

--- a/src/main/java/ewha/capston/cockChat/domain/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/ewha/capston/cockChat/domain/chat/repository/ChatRoomRepository.java
@@ -11,7 +11,7 @@ import java.util.Optional;
 //@Repository
 public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
     Boolean existsByIdentifier(String identifier);
-
     Optional<ChatRoom> findByIdentifier(String code);
+    List<ChatRoom> findByRoomNameContaining(String roomName);
 }
 

--- a/src/main/java/ewha/capston/cockChat/domain/chat/service/ChatRoomParticipantService.java
+++ b/src/main/java/ewha/capston/cockChat/domain/chat/service/ChatRoomParticipantService.java
@@ -78,7 +78,7 @@ public class ChatRoomParticipantService {
 
         Participant owner = participantRepository.findByMemberAndChatRoom(member,chatRoom)
                 .orElseThrow(()->new CustomException(ErrorCode.INVALID_PARTICIPANT));
-        if(owner.getIsOwner().equals(Boolean.FALSE)) throw new CustomException(ErrorCode.INVALID_HOST);
+        if(owner.getIsOwner().equals(Boolean.FALSE)) throw new CustomException(ErrorCode.INVALID_OWNER);
 
         Participant newOwner = participantRepository.findById(requestDto.getNewOwnerId())
                 .orElseThrow(()-> new CustomException(ErrorCode.INVALID_PARTICIPANT));
@@ -89,5 +89,25 @@ public class ChatRoomParticipantService {
 
         return ResponseEntity.status(HttpStatus.OK)
                 .body(ParticipantResponseDto.of(newOwner));
+    }
+
+
+    /* 방장 권한 회원 탈퇴 */
+    public ResponseEntity<Void> removeParticipantByOwner(Member member, Long chatRoomId, Long participantId) {
+        ChatRoom chatRoom = chatRoomRepository.findById(chatRoomId)
+                .orElseThrow(()->new CustomException(ErrorCode.INVALID_ROOM));
+
+        Participant owner = participantRepository.findByMemberAndChatRoom(member,chatRoom)
+                .orElseThrow(()->new CustomException(ErrorCode.INVALID_PARTICIPANT));
+        if(owner.getIsOwner().equals(Boolean.FALSE)) throw new CustomException(ErrorCode.INVALID_OWNER);
+
+        Participant participant = participantRepository.findById(participantId)
+                .orElseThrow(()-> new CustomException(ErrorCode.INVALID_PARTICIPANT));
+        if(!participant.getChatRoom().equals(chatRoom)) throw new CustomException(ErrorCode.NOT_A_PARTICIPANT);
+        if(participant.getIsOwner().equals(Boolean.TRUE)) throw new CustomException(ErrorCode.CANNOT_REMOVE_OWNER);
+
+        participantRepository.delete(participant);
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(null);
     }
 }

--- a/src/main/java/ewha/capston/cockChat/domain/chat/service/ChatRoomService.java
+++ b/src/main/java/ewha/capston/cockChat/domain/chat/service/ChatRoomService.java
@@ -15,6 +15,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 
 import java.security.SecureRandom;
+import java.util.ArrayList;
+import java.util.List;
 
 @Service
 @Transactional
@@ -58,8 +60,6 @@ public class ChatRoomService {
                 .body(ChatRoomResponseDto.of(chatRoom));
     }
 
-
-
     /* 랜덤 문자열 생성 */
     public  String generateRandomMixStr(int length, boolean isUpperCase) {
         String characters = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
@@ -74,4 +74,16 @@ public class ChatRoomService {
         return isUpperCase ? sb.toString() : sb.toString().toLowerCase();
     }
 
+    /* 채팅방 이름으로 채팅방 조회 */
+    public ResponseEntity<List<ChatRoomResponseDto>> getChatRoomListByRoomName(String roomName) {
+        List<ChatRoom> chatRoomList = chatRoomRepository.findByRoomNameContaining(roomName);
+        List<ChatRoomResponseDto> responseDtoList = new ArrayList<>();
+        for(ChatRoom chatRoom : chatRoomList){
+            if(chatRoom.getIsSecretChatRoom().equals(Boolean.FALSE)){
+                responseDtoList.add(ChatRoomResponseDto.of(chatRoom));
+            }
+        }
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(responseDtoList);
+    }
 }

--- a/src/main/java/ewha/capston/cockChat/domain/chat/service/ChatRoomService.java
+++ b/src/main/java/ewha/capston/cockChat/domain/chat/service/ChatRoomService.java
@@ -5,6 +5,7 @@ import ewha.capston.cockChat.domain.chat.dto.ChatRoomRequestDto;
 import ewha.capston.cockChat.domain.chat.dto.ChatRoomResponseDto;
 import ewha.capston.cockChat.domain.chat.repository.ChatRoomRepository;
 import ewha.capston.cockChat.domain.member.domain.Member;
+import ewha.capston.cockChat.domain.participant.domain.Participant;
 import ewha.capston.cockChat.domain.participant.repository.ParticipantRepository;
 import ewha.capston.cockChat.global.exception.CustomException;
 import ewha.capston.cockChat.global.exception.ErrorCode;
@@ -86,4 +87,23 @@ public class ChatRoomService {
         return ResponseEntity.status(HttpStatus.OK)
                 .body(responseDtoList);
     }
+
+    /* 채팅방 삭제 */
+    public ResponseEntity<Void> removeChatRoom(Member member, Long chatRoomId) {
+        ChatRoom chatRoom = chatRoomRepository.findById(chatRoomId)
+                .orElseThrow(()->new CustomException(ErrorCode.INVALID_ROOM));
+        Participant owner = participantRepository.findByMemberAndChatRoom(member,chatRoom)
+                .orElseThrow(()->new CustomException(ErrorCode.INVALID_PARTICIPANT));
+        if(owner.getIsOwner().equals(Boolean.FALSE)) throw new CustomException(ErrorCode.INVALID_OWNER);
+
+        List<Participant> participantList = participantRepository.findAllByChatRoom(chatRoom);
+        for(Participant participant : participantList){
+            participantRepository.delete(participant);
+        }
+
+        chatRoomRepository.delete(chatRoom);
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(null);
+    }
+
 }

--- a/src/main/java/ewha/capston/cockChat/domain/participant/domain/Participant.java
+++ b/src/main/java/ewha/capston/cockChat/domain/participant/domain/Participant.java
@@ -50,9 +50,17 @@ public class Participant {
         this.member = member;
     }
 
+    /* 키워드 설정 업데이트 */
     public void updateSettings(String positiveKeywords, String negativeKeywords){
         this.positiveKeywords = positiveKeywords;
         this.negativeKeywords = negativeKeywords;
     }
+
+    /* 방장 권한 업데이트 */
+    public void updateIsOwner(Boolean isOwner){
+        this.isOwner = isOwner;
+    }
+
+
 
 }

--- a/src/main/java/ewha/capston/cockChat/domain/participant/dto/OwnerRequestDto.java
+++ b/src/main/java/ewha/capston/cockChat/domain/participant/dto/OwnerRequestDto.java
@@ -1,0 +1,10 @@
+package ewha.capston.cockChat.domain.participant.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class OwnerRequestDto {
+    private Long newOwnerId;
+}

--- a/src/main/java/ewha/capston/cockChat/domain/participant/repository/ParticipantRepository.java
+++ b/src/main/java/ewha/capston/cockChat/domain/participant/repository/ParticipantRepository.java
@@ -14,4 +14,6 @@ public interface ParticipantRepository extends JpaRepository<Participant, Long> 
     Optional<Participant> findByMemberAndChatRoom(Member member, ChatRoom chatRoom);
 
     List<Participant> findAllByMember(Member member);
+
+    List<Participant> findAllByChatRoom(ChatRoom chatRoom);
 }

--- a/src/main/java/ewha/capston/cockChat/global/exception/ErrorCode.java
+++ b/src/main/java/ewha/capston/cockChat/global/exception/ErrorCode.java
@@ -27,8 +27,9 @@ public enum ErrorCode {
 
     /* participant */
     INVALID_PARTICIPANT(HttpStatus.BAD_REQUEST,"잘못된 채팅 참여자입니다."),
-    INVALID_HOST(HttpStatus.FORBIDDEN, "방장 권한이 없습니다."),
+    INVALID_OWNER(HttpStatus.FORBIDDEN, "방장 권한이 없습니다."),
     NOT_A_PARTICIPANT(HttpStatus.BAD_REQUEST, "채팅방에 참여 중인 회원이 아닙니다."),
+    CANNOT_REMOVE_OWNER(HttpStatus.BAD_REQUEST, "방장은 탈퇴할 수 없습니다."),
 
     /* file */
     INPUT_IS_NULL(HttpStatus.BAD_REQUEST,"입력으로 null이 들어왔습니다."),

--- a/src/main/java/ewha/capston/cockChat/global/exception/ErrorCode.java
+++ b/src/main/java/ewha/capston/cockChat/global/exception/ErrorCode.java
@@ -27,6 +27,8 @@ public enum ErrorCode {
 
     /* participant */
     INVALID_PARTICIPANT(HttpStatus.BAD_REQUEST,"잘못된 채팅 참여자입니다."),
+    INVALID_HOST(HttpStatus.FORBIDDEN, "방장 권한이 없습니다."),
+    NOT_A_PARTICIPANT(HttpStatus.BAD_REQUEST, "채팅방에 참여 중인 회원이 아닙니다."),
 
     /* file */
     INPUT_IS_NULL(HttpStatus.BAD_REQUEST,"입력으로 null이 들어왔습니다."),


### PR DESCRIPTION
## 📄 feat : 방장 변경 / 채팅방 조회 / 채팅방 삭제
- 채팅방의 방장 변경 기능
- 채팅방의 이름으로 해당 문자열 포함된 모든 채팅방 목록 조회
- 방장 권한으로 채팅방 삭제

## 📌 변경 사항
- 방장 변경 기능 추가.
- 채팅방 이름으로 채팅방 조회 기능 추가.
- 방장 권한으로 채팅방 삭제 기능 추가.
  - 채팅방 삭제 시 해당 채팅방에 참여중인 모든 참여자도 DB에서 삭제함.
- 방장 권한이 없는 회원이 방장 변경/채팅방 삭제 api를 호출한 경우 예외를 발생시킴.


## 🔍 주요 변경 파일 및 내용
- [x] `ChatRoomController.java` & `ChatRoomService.java` : 채팅방 조회 및 채팅방 삭제 기능 구현
- [x] `ChatRoomParticipantController.java` & `ChatRoomParticipantService.java` : 방장 변경 기능 구현


## ✅ 체크리스트
PR 제출 전 확인해야 할 사항:
- [x] 코드가 올바르게 동작하는지 확인
- [x] 테스트 코드 추가 및 정상 동작 확인
- [x] 문서 업데이트 여부 확인 (README, 위키 등)
- [x] 리뷰어에게 전달할 추가 정보 작성


## 📎 참고 자료
- 없어용
