### PR TITLE
feat : 채팅 내역 조회 구현, 응답 필드 추가

### DIFF
--- a/src/main/java/ewha/capston/cockChat/domain/chat/controller/ChatController.java
+++ b/src/main/java/ewha/capston/cockChat/domain/chat/controller/ChatController.java
@@ -1,7 +1,6 @@
 package ewha.capston.cockChat.domain.chat.controller;
 
 import ewha.capston.cockChat.domain.chat.dto.ChatMessageRequestDto;
-import ewha.capston.cockChat.domain.chat.dto.ChatResponseDto;
 import ewha.capston.cockChat.domain.chat.service.ChatService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/java/ewha/capston/cockChat/domain/chat/controller/ChatController.java
+++ b/src/main/java/ewha/capston/cockChat/domain/chat/controller/ChatController.java
@@ -1,14 +1,20 @@
 package ewha.capston.cockChat.domain.chat.controller;
 
 import ewha.capston.cockChat.domain.chat.dto.ChatMessageRequestDto;
+import ewha.capston.cockChat.domain.chat.dto.ChatResponseDto;
 import ewha.capston.cockChat.domain.chat.service.ChatService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
 import org.springframework.messaging.handler.annotation.DestinationVariable;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.messaging.handler.annotation.SendTo;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+import java.util.List;
 
 @Controller
 @Slf4j
@@ -22,5 +28,11 @@ public class ChatController {
     public void sendMessage(@Payload  ChatMessageRequestDto requestDto){
         log.info("Received message request: {}", requestDto);
         chatService.sendMessage(requestDto.getRoomId(), requestDto);
+    }
+
+    /* 채팅 내역 조회 */
+    @GetMapping("/chats/{chatRoomId}/messages")
+    public ResponseEntity<List<ChatResponseDto>> getChatMessageList(@PathVariable(name = "chatRoomId") Long chatRoomId){
+        return chatService.getChatMessageList(chatRoomId);
     }
 }

--- a/src/main/java/ewha/capston/cockChat/domain/chat/dto/ChatResponseDto.java
+++ b/src/main/java/ewha/capston/cockChat/domain/chat/dto/ChatResponseDto.java
@@ -1,10 +1,13 @@
 package ewha.capston.cockChat.domain.chat.dto;
 
+import ewha.capston.cockChat.domain.chat.domain.Chat;
 import ewha.capston.cockChat.domain.chat.domain.MessageType;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+
+import java.time.LocalDateTime;
 
 @Getter
 @Builder
@@ -14,4 +17,15 @@ public class ChatResponseDto {
     private Long senderId;
     private MessageType type;
     private String content;
+    private LocalDateTime createdAt;
+
+    public static ChatResponseDto of(Chat chat){
+        return ChatResponseDto.builder()
+                .roomId(chat.getChatroomId())
+                .senderId(chat.getParticipantId())
+                .type(chat.getMessageType())
+                .content(chat.getMessage())
+                .createdAt(chat.getCreatedDate())
+                .build();
+    }
 }

--- a/src/main/java/ewha/capston/cockChat/domain/chat/dto/ChatRoomResponseDto.java
+++ b/src/main/java/ewha/capston/cockChat/domain/chat/dto/ChatRoomResponseDto.java
@@ -1,5 +1,6 @@
 package ewha.capston.cockChat.domain.chat.dto;
 
+import ewha.capston.cockChat.domain.chat.domain.Chat;
 import ewha.capston.cockChat.domain.chat.domain.ChatRoom;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -13,23 +14,25 @@ public class ChatRoomResponseDto {
 
     private Long roomId;
     private String identifier;
-    private Long lastChat;
     private String roomName;
     private Boolean isSecretChatRoom;
     private Long password;
     private Boolean isAnonymousChatRoom;
     private String chatRoomImgUrl;
+    private Long participantCount;
+    private ChatResponseDto latestChat;
 
-    public static ChatRoomResponseDto of(ChatRoom chatRoom){
+    public static ChatRoomResponseDto of(ChatRoom chatRoom, Long participantCount, Chat chat){
         return ChatRoomResponseDto.builder()
                 .roomId(chatRoom.getRoomId())
                 .identifier(chatRoom.getIdentifier())
-                .lastChat(0L) // 이후 수정
                 .roomName(chatRoom.getRoomName())
                 .isSecretChatRoom(chatRoom.getIsSecretChatRoom())
                 .password(chatRoom.getPassword())
                 .isAnonymousChatRoom(chatRoom.getIsAnonymousChatRoom())
                 .chatRoomImgUrl(chatRoom.getChatRoomImgUrl())
+                .participantCount(participantCount)
+                .latestChat(chat != null ? ChatResponseDto.of(chat) : null)
                 .build();
     }
 }

--- a/src/main/java/ewha/capston/cockChat/domain/chat/mongo/MongoChatRepository.java
+++ b/src/main/java/ewha/capston/cockChat/domain/chat/mongo/MongoChatRepository.java
@@ -6,4 +6,6 @@ import org.springframework.stereotype.Repository;
 
 //@Repository
 public interface MongoChatRepository extends MongoRepository<Chat, String> {
+    Chat findTopByChatroomIdOrderByCreatedDateDesc(Long chatroomId);
 }
+

--- a/src/main/java/ewha/capston/cockChat/domain/chat/mongo/MongoChatRepository.java
+++ b/src/main/java/ewha/capston/cockChat/domain/chat/mongo/MongoChatRepository.java
@@ -4,8 +4,11 @@ import ewha.capston.cockChat.domain.chat.domain.Chat;
 import org.springframework.data.mongodb.repository.MongoRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 //@Repository
 public interface MongoChatRepository extends MongoRepository<Chat, String> {
     Chat findTopByChatroomIdOrderByCreatedDateDesc(Long chatroomId);
+    List<Chat> findAllByChatroomIdOrderByCreatedDateAsc(Long chatRoomId);
 }
 

--- a/src/main/java/ewha/capston/cockChat/domain/chat/service/ChatRoomParticipantService.java
+++ b/src/main/java/ewha/capston/cockChat/domain/chat/service/ChatRoomParticipantService.java
@@ -30,6 +30,8 @@ public class ChatRoomParticipantService {
     private final ChatRoomRepository chatRoomRepository;
     private final ParticipantRepository participantRepository;
 
+    private final ChatRoomService chatRoomService;
+
     /* 참여 중인 모든 채팅방 목록 조회 */
     public ResponseEntity<List<ChatRoomResponseDto>> getChatRoomsByMember(Member member) {
         List<Participant> participantList = participantRepository.findAllByMember(member);
@@ -39,8 +41,9 @@ public class ChatRoomParticipantService {
                     .orElseThrow(()->new CustomException(ErrorCode.INVALID_ROOM));
             chatRoomList.add(chatRoom);
         }
+
         return ResponseEntity.status(HttpStatus.OK)
-                .body(chatRoomList.stream().map(ChatRoomResponseDto::of).collect(Collectors.toList()));
+                .body(chatRoomList.stream().map(chatRoomService::makeChatRoomResponseDto).collect(Collectors.toList()));
     }
 
 

--- a/src/main/java/ewha/capston/cockChat/domain/chat/service/ChatRoomService.java
+++ b/src/main/java/ewha/capston/cockChat/domain/chat/service/ChatRoomService.java
@@ -1,8 +1,10 @@
 package ewha.capston.cockChat.domain.chat.service;
 
+import ewha.capston.cockChat.domain.chat.domain.Chat;
 import ewha.capston.cockChat.domain.chat.domain.ChatRoom;
 import ewha.capston.cockChat.domain.chat.dto.ChatRoomRequestDto;
 import ewha.capston.cockChat.domain.chat.dto.ChatRoomResponseDto;
+import ewha.capston.cockChat.domain.chat.mongo.MongoChatRepository;
 import ewha.capston.cockChat.domain.chat.repository.ChatRoomRepository;
 import ewha.capston.cockChat.domain.member.domain.Member;
 import ewha.capston.cockChat.domain.participant.domain.Participant;
@@ -25,6 +27,7 @@ import java.util.List;
 public class ChatRoomService {
 
     private final ChatRoomRepository chatRoomRepository;
+    private final MongoChatRepository mongoChatRepository;
     private final ParticipantRepository participantRepository;
 
 
@@ -49,7 +52,7 @@ public class ChatRoomService {
                 .build());
 
         return ResponseEntity.status(HttpStatus.CREATED)
-                .body(ChatRoomResponseDto.of(chatRoom));
+                .body(makeChatRoomResponseDto(chatRoom));
     }
 
 
@@ -58,7 +61,7 @@ public class ChatRoomService {
         ChatRoom chatRoom = chatRoomRepository.findByIdentifier(code)
                 .orElseThrow(()->new CustomException(ErrorCode.INVALID_ROOM));
         return ResponseEntity.status(HttpStatus.OK)
-                .body(ChatRoomResponseDto.of(chatRoom));
+                .body(makeChatRoomResponseDto(chatRoom));
     }
 
     /* 랜덤 문자열 생성 */
@@ -81,7 +84,7 @@ public class ChatRoomService {
         List<ChatRoomResponseDto> responseDtoList = new ArrayList<>();
         for(ChatRoom chatRoom : chatRoomList){
             if(chatRoom.getIsSecretChatRoom().equals(Boolean.FALSE)){
-                responseDtoList.add(ChatRoomResponseDto.of(chatRoom));
+                responseDtoList.add(makeChatRoomResponseDto(chatRoom));
             }
         }
         return ResponseEntity.status(HttpStatus.OK)
@@ -104,5 +107,10 @@ public class ChatRoomService {
         chatRoomRepository.delete(chatRoom);
         return ResponseEntity.status(HttpStatus.OK)
                 .body(null);
+    }
+
+    /* chatRoomResponseDto 생성 */
+    public ChatRoomResponseDto makeChatRoomResponseDto(ChatRoom chatRoom){
+        return ChatRoomResponseDto.of(chatRoom,participantRepository.countByChatRoom(chatRoom),mongoChatRepository.findTopByChatroomIdOrderByCreatedDateDesc(chatRoom.getRoomId()));
     }
 }

--- a/src/main/java/ewha/capston/cockChat/domain/chat/service/ChatService.java
+++ b/src/main/java/ewha/capston/cockChat/domain/chat/service/ChatService.java
@@ -4,6 +4,7 @@ import ewha.capston.cockChat.domain.chat.domain.Chat;
 import ewha.capston.cockChat.domain.chat.domain.ChatRoom;
 import ewha.capston.cockChat.domain.chat.domain.MessageType;
 import ewha.capston.cockChat.domain.chat.dto.ChatMessageRequestDto;
+import ewha.capston.cockChat.domain.chat.dto.ChatResponseDto;
 import ewha.capston.cockChat.domain.chat.dto.ChatRoomRequestDto;
 import ewha.capston.cockChat.domain.chat.dto.ChatRoomResponseDto;
 import ewha.capston.cockChat.domain.chat.mongo.MongoChatRepository;
@@ -22,6 +23,8 @@ import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Service;
 
 import java.security.SecureRandom;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @Transactional
@@ -68,4 +71,10 @@ public class ChatService {
         messagingTemplate.convertAndSend("/topic/public/" + roomId, chat);
     }
 
+    /* 채팅 내역 조회 */
+    public ResponseEntity<List<ChatResponseDto>> getChatMessageList(Long chatRoomId) {
+        List<Chat> chatList = mongoChatRepository.findAllByChatroomIdOrderByCreatedDateAsc(chatRoomId);
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(chatList.stream().map(ChatResponseDto::of).collect(Collectors.toList()));
+    }
 }

--- a/src/main/java/ewha/capston/cockChat/domain/participant/repository/ParticipantRepository.java
+++ b/src/main/java/ewha/capston/cockChat/domain/participant/repository/ParticipantRepository.java
@@ -16,4 +16,6 @@ public interface ParticipantRepository extends JpaRepository<Participant, Long> 
     List<Participant> findAllByMember(Member member);
 
     List<Participant> findAllByChatRoom(ChatRoom chatRoom);
+
+    Long countByChatRoom(ChatRoom chatRoom);
 }


### PR DESCRIPTION
## 📄 feat : 채팅 내역 조회 구현, 응답 필드 추가
- 채팅방 별 채팅 내역 조회 기능 구현
- 채팅방 조회 시 응답 필드 추가

## 📌 변경 사항
- 채팅방 조회 시 각 채팅방의 마지막 채팅과 채팅방의 채팅 참여자 수가 함께 반환되도록 응답 필드를 추가함.

## 🔍 주요 변경 파일 및 내용
- [x] `ChatRoomResponseDto.java` : `latestChat`, `participantCount` 필드를 추가함.
- [x] `ChatRoomService.java` : `makeChatRoomResponseDto()` 메소드를 작성함.
- [x] `ChatController.java` & `ChatService.java` : 채팅 내역 조회 기능을 구현함.

## ✅ 체크리스트
PR 제출 전 확인해야 할 사항:
- [x] 코드가 올바르게 동작하는지 확인
- [x] 테스트 코드 추가 및 정상 동작 확인
- [x] 문서 업데이트 여부 확인 (README, 위키 등)
- [x] 리뷰어에게 전달할 추가 정보 작성


## 📎 참고 자료
- 없어요!
