### PR TITLE
feat : 채팅방 비밀번호 검사 / 익명 프로필 응답 필드 추가

### DIFF
--- a/src/main/java/ewha/capston/cockChat/domain/chat/controller/ChatRoomController.java
+++ b/src/main/java/ewha/capston/cockChat/domain/chat/controller/ChatRoomController.java
@@ -41,6 +41,13 @@ public class ChatRoomController {
         return chatRoomService.getChatRoomListByRoomName(roomName);
     }
 
+    /* 채팅방 비밀번호 조회 */
+    @GetMapping("/chatRooms/{chatRoomId}/{password}")
+    public ResponseEntity<Boolean> checkChatRoomPassword(@AuthUser Member member, @PathVariable(name = "chatRoomId") Long chatRoomId,
+                                                         @PathVariable(name = "password")Long password ){
+        return chatRoomService.checkChatRoomPassword(chatRoomId,password);
+    }
+
     /* 채팅방 삭제 */
     @DeleteMapping("/chatRooms/{chatRoomId}")
     public ResponseEntity<Void> removeChatRoom(@AuthUser Member member, @PathVariable(name = "chatRoomId") Long chatRoomId){

--- a/src/main/java/ewha/capston/cockChat/domain/chat/service/ChatRoomService.java
+++ b/src/main/java/ewha/capston/cockChat/domain/chat/service/ChatRoomService.java
@@ -91,6 +91,14 @@ public class ChatRoomService {
                 .body(responseDtoList);
     }
 
+    /* 채팅방 비밀번호 확인*/
+    public ResponseEntity<Boolean> checkChatRoomPassword(Long chatRoomId, Long password) {
+        ChatRoom chatRoom = chatRoomRepository.findById(chatRoomId)
+                .orElseThrow(()->new CustomException(ErrorCode.INVALID_ROOM));
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(chatRoom.getPassword().equals(password));
+    }
+
     /* 채팅방 삭제 */
     public ResponseEntity<Void> removeChatRoom(Member member, Long chatRoomId) {
         ChatRoom chatRoom = chatRoomRepository.findById(chatRoomId)

--- a/src/main/java/ewha/capston/cockChat/domain/member/controller/MemberController.java
+++ b/src/main/java/ewha/capston/cockChat/domain/member/controller/MemberController.java
@@ -12,7 +12,6 @@ import ewha.capston.cockChat.domain.participant.dto.ParticipantResponseDto;
 import ewha.capston.cockChat.domain.participant.service.ParticipantService;
 import ewha.capston.cockChat.global.config.auth.AuthUser;
 import jakarta.servlet.http.HttpServletRequest;
-import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;

--- a/src/main/java/ewha/capston/cockChat/domain/participant/dto/ParticipantResponseDto.java
+++ b/src/main/java/ewha/capston/cockChat/domain/participant/dto/ParticipantResponseDto.java
@@ -13,6 +13,7 @@ public class ParticipantResponseDto {
     private Long participantId;
     private String roomNickname;
     private Long roomId;
+    private String roomName;
     private Boolean isOwner;
     private String participantImgUrl;
 
@@ -21,6 +22,7 @@ public class ParticipantResponseDto {
                 .participantId(participant.getParticipantId())
                 .roomNickname(participant.getRoomNickname())
                 .roomId(participant.getChatRoom().getRoomId())
+                .roomName(participant.getChatRoom().getRoomName())
                 .isOwner(participant.getIsOwner())
                 .participantImgUrl(participant.getParticipantImgUrl())
                 .build();

--- a/src/main/java/ewha/capston/cockChat/domain/participant/service/ParticipantService.java
+++ b/src/main/java/ewha/capston/cockChat/domain/participant/service/ParticipantService.java
@@ -18,7 +18,6 @@ import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 
 @Service
 @Transactional


### PR DESCRIPTION
## 📄 feat : 채팅방 비밀번호 검사 / 익명 프로필 응답 필드 추가
- 채팅방의 비밀번호를 조회하는 기능 추가
- 익명 프로필 조회 시 반환되는 응답 필드를 추가

## 📌 변경 사항
- 익명 프로필 조회 시 해당 익명 프로필이 이용되는 채팅방의 이름(=`roomName`) 필드를 추가로 반환함.

## 🔍 주요 변경 파일 및 내용
- [x] `ParticipantResponseDto.java` : 응답 필드 추가
- [x] `ChatRoomService.java` & `ChatRoomController.java`  : 채팅방 비밀번호 조회 로직 추가

## ✅ 체크리스트
PR 제출 전 확인해야 할 사항:
- [x] 코드가 올바르게 동작하는지 확인
- [x] 테스트 코드 추가 및 정상 동작 확인
- [x] 문서 업데이트 여부 확인 (README, 위키 등)
- [x] 리뷰어에게 전달할 추가 정보 작성


## 📎 참고 자료
- 없어요!