### PR TITLE
refactor : 채팅방 탈퇴 및 참여자 조회 로직 수정

### DIFF
--- a/src/main/java/ewha/capston/cockChat/domain/participant/domain/Participant.java
+++ b/src/main/java/ewha/capston/cockChat/domain/participant/domain/Participant.java
@@ -33,6 +33,9 @@ public class Participant {
     @Column
     private String participantImgUrl;
 
+    @Column
+    private Boolean isActive;
+
     @ManyToOne
     @JoinColumn(name = "chatRoom_id")
     private ChatRoom chatRoom;
@@ -42,8 +45,9 @@ public class Participant {
     private Member member;
 
     @Builder
-    public Participant(Boolean isOwner, String roomNickname, String participantImgUrl, ChatRoom chatRoom, Member member){
+    public Participant(Boolean isOwner, Boolean isActive, String roomNickname, String participantImgUrl, ChatRoom chatRoom, Member member){
         this.isOwner = isOwner;
+        this.isActive = isActive;
         this.roomNickname = roomNickname;
         this.participantImgUrl = participantImgUrl;
         this.chatRoom = chatRoom;
@@ -67,6 +71,8 @@ public class Participant {
         this.participantImgUrl = member.getProfileImgUrl();
     }
 
-
-
+    /* 채팅방 탈퇴 */
+    public void deactivateParticipant(){
+        this.isActive = Boolean.FALSE;
+    }
 }

--- a/src/main/java/ewha/capston/cockChat/domain/participant/repository/ParticipantRepository.java
+++ b/src/main/java/ewha/capston/cockChat/domain/participant/repository/ParticipantRepository.java
@@ -10,10 +10,14 @@ import java.util.Optional;
 
 public interface ParticipantRepository extends JpaRepository<Participant, Long> {
     Boolean existsByChatRoomAndMember(ChatRoom chatRoom, Member member);
+    Boolean existsByChatRoomAndMemberAndIsActiveTrue(ChatRoom chatRoom, Member member);
 
     Optional<Participant> findByMemberAndChatRoom(Member member, ChatRoom chatRoom);
+    Optional<Participant> findByMemberAndChatRoomAndIsActiveTrue(Member member, ChatRoom chatRoom);
 
     List<Participant> findAllByMember(Member member);
+    List<Participant> findAllByMemberAndIsActiveTrue(Member member);
+
 
     List<Participant> findAllByChatRoom(ChatRoom chatRoom);
 

--- a/src/main/java/ewha/capston/cockChat/domain/participant/service/ParticipantService.java
+++ b/src/main/java/ewha/capston/cockChat/domain/participant/service/ParticipantService.java
@@ -32,12 +32,13 @@ public class ParticipantService {
         ChatRoom chatRoom = chatRoomRepository.findById(chatRoomId)
                 .orElseThrow(()->new CustomException(ErrorCode.INVALID_ROOM));
 
-        if(participantRepository.existsByChatRoomAndMember(chatRoom,member).equals(Boolean.TRUE))
+        if(participantRepository.existsByChatRoomAndMemberAndIsActiveTrue(chatRoom,member).equals(Boolean.TRUE))
             throw new CustomException(ErrorCode.ALREADY_JOINED_MEMBER);
 
         Participant participant = participantRepository.save(
                 Participant.builder()
                         .isOwner(requestDto.getIsOwner())
+                        .isActive(Boolean.TRUE)
                         .roomNickname(member.getNickname())
                         .participantImgUrl(member.getProfileImgUrl())
                         .chatRoom(chatRoom)
@@ -54,12 +55,14 @@ public class ParticipantService {
     public ResponseEntity<ParticipantResponseDto> joinAnonymousChatroom(Member member, Long chatRoomId, ParticipantAnonymousRequestDto requestDto) {
         ChatRoom chatRoom = chatRoomRepository.findById(chatRoomId)
                 .orElseThrow(()->new CustomException(ErrorCode.INVALID_ROOM));
-        if(participantRepository.existsByChatRoomAndMember(chatRoom,member).equals(Boolean.TRUE))
+
+        if(participantRepository.existsByChatRoomAndMemberAndIsActiveTrue(chatRoom,member).equals(Boolean.TRUE))
             throw new CustomException(ErrorCode.ALREADY_JOINED_MEMBER);
 
         Participant participant = participantRepository.save(
                 Participant.builder()
                         .isOwner(requestDto.getIsOwner())
+                        .isActive(Boolean.TRUE)
                         .roomNickname(requestDto.getRoomNickname())
                         .participantImgUrl(requestDto.getParticipantImgUrl())
                         .chatRoom(chatRoom)
@@ -73,7 +76,7 @@ public class ParticipantService {
 
     /* 회원의 익명 프로필 목록 조회 */
     public ResponseEntity<List<ParticipantResponseDto>> getAnonymousProfileListByMember(Member member) {
-        List<Participant> participantList = participantRepository.findAllByMember(member);
+        List<Participant> participantList = participantRepository.findAllByMemberAndIsActiveTrue(member);
         List<ParticipantResponseDto> responseDtoList = new ArrayList<>();
         for(Participant participant : participantList){
             if(participant.getChatRoom().getIsAnonymousChatRoom().equals(Boolean.TRUE)){
@@ -86,7 +89,7 @@ public class ParticipantService {
 
     /* 실명 사용 모든 프로필 업데이트 */
     public void updateAllRealNameProfileList(Member member) {
-        List<Participant> participantList = participantRepository.findAllByMember(member);
+        List<Participant> participantList = participantRepository.findAllByMemberAndIsActiveTrue(member);
         participantList.stream()
                 .filter(participant -> Boolean.FALSE.equals(participant.getChatRoom().getIsAnonymousChatRoom()))
                 .forEach(participant -> participant.updateRealNameParticipant(member));


### PR DESCRIPTION
## 📄 채팅방 탈퇴 및 참여자 조회 로직 수정
- PR에 대한 간략한 설명 작성

## 📌 변경 사항
- Participant 엔티티에 isActive 필드 추가
- 현재 활동 중인 참가자만 조회하도록 Repository 메서드 수정
  - findByMemberAndChatRoomAndIsActiveTrue 추가
  - existsByChatRoomAndMemberAndIsActiveTrue 추가
  - findAllByMemberAndIsActiveTrue 추가
- 채팅방 탈퇴 메서드(leaveChatRoom) 구현 (isActive=false 처리)

## 🔍 주요 변경 파일 및 내용
- [ ] `Participant.java` : isActive 필드 추가, 채팅방 탈퇴 메서드(leaveChatRoom) 구현 (isActive=false 처리)
- [ ]  `ParticipantRespository.java` :   메서드 `findByMemberAndChatRoomAndIsActiveTrue`, `existsByChatRoomAndMemberAndIsActiveTrue`, `findAllByMemberAndIsActiveTrue` 추가

## ✅ 체크리스트
PR 제출 전 확인해야 할 사항:
- [ ] 코드가 올바르게 동작하는지 확인
- [ ] 테스트 코드 추가 및 정상 동작 확인
- [ ] 문서 업데이트 여부 확인 (README, 위키 등)
- [ ] 리뷰어에게 전달할 추가 정보 작성


## 📎 참고 자료
- 없어요!
