### PR TITLE
feat : id로 익명 프로필 조회 기능 구현

### DIFF
--- a/src/main/java/ewha/capston/cockChat/domain/participant/controller/ParticipantController.java
+++ b/src/main/java/ewha/capston/cockChat/domain/participant/controller/ParticipantController.java
@@ -7,6 +7,7 @@ import ewha.capston.cockChat.domain.participant.dto.ParticipantAnonymousRequestD
 import ewha.capston.cockChat.domain.participant.dto.ParticipantResponseDto;
 import ewha.capston.cockChat.domain.participant.service.ParticipantService;
 import ewha.capston.cockChat.global.config.auth.AuthUser;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -34,6 +35,12 @@ public class ParticipantController {
     @PutMapping("/participants/{participantId}/anonymous")
     public ResponseEntity<ParticipantResponseDto> updateAnonymousProfile(@AuthUser Member member, @PathVariable Long participantId, @RequestBody MemberUpdateRequestDto requestDto){
         return participantService.updateAnonymousProfile(member, participantId, requestDto);
+    }
+
+    /* 프로필 조회 */
+    @GetMapping("/participants/{participantId}")
+    public ResponseEntity<ParticipantResponseDto> getParticipant(@AuthUser Member member, @PathVariable Long participantId){
+        return participantService.getParticipant(member, participantId);
     }
 
 }

--- a/src/main/java/ewha/capston/cockChat/domain/participant/service/ParticipantService.java
+++ b/src/main/java/ewha/capston/cockChat/domain/participant/service/ParticipantService.java
@@ -108,4 +108,12 @@ public class ParticipantService {
                 .body(ParticipantResponseDto.of(participant));
 
     }
+
+    /* 프로필 조회 */
+    public ResponseEntity<ParticipantResponseDto> getParticipant(Member member, Long participantId) {
+        Participant participant = participantRepository.findById(participantId)
+                .orElseThrow(()->new CustomException(ErrorCode.INVALID_PARTICIPANT));
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(ParticipantResponseDto.of(participant));
+    }
 }


### PR DESCRIPTION
## 📄 feat : id로 익명 프로필 조회 기능 구현
- participantId 를 통해 participant를 조회하는 기능을 구현.
- participant의 응답값으로 participant의 이름, 방장 여부, 대표 이미지 등 프로필 정보가 반환됨.
- 만약 participant가 실명 채팅방에 참여중인 참여자라면 반환되는 값은 익명 프로필 정보가 아닌 실명 프로필 정보임.

## 📌 변경 사항
- participantId를 통해 participant 한 개 조회하도록 기능 추가.

## 🔍 주요 변경 파일 및 내용
- [x] `ParticipantController.java` & `ParticipantService.java` : 조회 기능 구현.


## ✅ 체크리스트
PR 제출 전 확인해야 할 사항:
- [x] 코드가 올바르게 동작하는지 확인
- [x] 테스트 코드 추가 및 정상 동작 확인
- [x] 문서 업데이트 여부 확인 (README, 위키 등)
- [x] 리뷰어에게 전달할 추가 정보 작성


## 📎 참고 자료
- 없어요!
