### PR TITLE
feat : 채팅방 상세 정보 조회 기능 구현

### DIFF
--- a/src/main/java/ewha/capston/cockChat/domain/chat/controller/ChatRoomController.java
+++ b/src/main/java/ewha/capston/cockChat/domain/chat/controller/ChatRoomController.java
@@ -1,5 +1,6 @@
 package ewha.capston.cockChat.domain.chat.controller;
 
+import ewha.capston.cockChat.domain.chat.dto.ChatRoomInfoDto;
 import ewha.capston.cockChat.domain.chat.dto.ChatRoomRequestDto;
 import ewha.capston.cockChat.domain.chat.dto.ChatRoomResponseDto;
 import ewha.capston.cockChat.domain.chat.service.ChatRoomService;
@@ -46,6 +47,12 @@ public class ChatRoomController {
     public ResponseEntity<Boolean> checkChatRoomPassword(@AuthUser Member member, @PathVariable(name = "chatRoomId") Long chatRoomId,
                                                          @PathVariable(name = "password")Long password ){
         return chatRoomService.checkChatRoomPassword(chatRoomId,password);
+    }
+
+    /* 채팅방 상세 정보 조회 */
+    @GetMapping("/chatRooms/{chatRoomId}/info")
+    public ResponseEntity<ChatRoomInfoDto> getChatRoomInfo(@AuthUser Member member, @PathVariable(name = "chatRoomId") Long chatRoomId){
+        return chatRoomService.getChatRoomInfo(member, chatRoomId);
     }
 
     /* 채팅방 삭제 */

--- a/src/main/java/ewha/capston/cockChat/domain/chat/dto/ChatRoomInfoDto.java
+++ b/src/main/java/ewha/capston/cockChat/domain/chat/dto/ChatRoomInfoDto.java
@@ -1,0 +1,30 @@
+package ewha.capston.cockChat.domain.chat.dto;
+
+import ewha.capston.cockChat.domain.chat.domain.ChatRoom;
+import ewha.capston.cockChat.domain.participant.domain.Participant;
+import ewha.capston.cockChat.domain.participant.dto.ParticipantResponseDto;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+public class ChatRoomInfoDto {
+    private String roomName;
+    private String identifier;
+    private List<ParticipantResponseDto> participantList;
+
+    public static ChatRoomInfoDto of(ChatRoom chatRoom, List<ParticipantResponseDto> responseDtoList){
+        return ChatRoomInfoDto.builder()
+                .roomName(chatRoom.getRoomName())
+                .identifier(chatRoom.getIdentifier())
+                .participantList(responseDtoList)
+                .build();
+    }
+
+
+}

--- a/src/main/java/ewha/capston/cockChat/domain/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/ewha/capston/cockChat/domain/chat/repository/ChatRoomRepository.java
@@ -13,5 +13,6 @@ public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
     Boolean existsByIdentifier(String identifier);
     Optional<ChatRoom> findByIdentifier(String code);
     List<ChatRoom> findByRoomNameContaining(String roomName);
+
 }
 

--- a/src/main/java/ewha/capston/cockChat/domain/chat/service/ChatRoomService.java
+++ b/src/main/java/ewha/capston/cockChat/domain/chat/service/ChatRoomService.java
@@ -2,12 +2,14 @@ package ewha.capston.cockChat.domain.chat.service;
 
 import ewha.capston.cockChat.domain.chat.domain.Chat;
 import ewha.capston.cockChat.domain.chat.domain.ChatRoom;
+import ewha.capston.cockChat.domain.chat.dto.ChatRoomInfoDto;
 import ewha.capston.cockChat.domain.chat.dto.ChatRoomRequestDto;
 import ewha.capston.cockChat.domain.chat.dto.ChatRoomResponseDto;
 import ewha.capston.cockChat.domain.chat.mongo.MongoChatRepository;
 import ewha.capston.cockChat.domain.chat.repository.ChatRoomRepository;
 import ewha.capston.cockChat.domain.member.domain.Member;
 import ewha.capston.cockChat.domain.participant.domain.Participant;
+import ewha.capston.cockChat.domain.participant.dto.ParticipantResponseDto;
 import ewha.capston.cockChat.domain.participant.repository.ParticipantRepository;
 import ewha.capston.cockChat.global.exception.CustomException;
 import ewha.capston.cockChat.global.exception.ErrorCode;
@@ -20,6 +22,7 @@ import org.springframework.stereotype.Service;
 import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @Transactional
@@ -90,6 +93,16 @@ public class ChatRoomService {
         return ResponseEntity.status(HttpStatus.OK)
                 .body(responseDtoList);
     }
+
+    /* 채팅방 상세 정보 조회 */
+    public ResponseEntity<ChatRoomInfoDto> getChatRoomInfo(Member member, Long chatRoomId) {
+        ChatRoom chatRoom = chatRoomRepository.findById(chatRoomId)
+                .orElseThrow(()->new CustomException(ErrorCode.INVALID_ROOM));
+        List<Participant> participantList = participantRepository.findAllByChatRoomAndIsActiveTrue(chatRoom);
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(ChatRoomInfoDto.of(chatRoom, participantList.stream().map(ParticipantResponseDto::of).collect(Collectors.toList())));
+    }
+
 
     /* 채팅방 비밀번호 확인*/
     public ResponseEntity<Boolean> checkChatRoomPassword(Long chatRoomId, Long password) {

--- a/src/main/java/ewha/capston/cockChat/domain/participant/repository/ParticipantRepository.java
+++ b/src/main/java/ewha/capston/cockChat/domain/participant/repository/ParticipantRepository.java
@@ -18,8 +18,9 @@ public interface ParticipantRepository extends JpaRepository<Participant, Long> 
     List<Participant> findAllByMember(Member member);
     List<Participant> findAllByMemberAndIsActiveTrue(Member member);
 
-
     List<Participant> findAllByChatRoom(ChatRoom chatRoom);
+
+    List<Participant> findAllByChatRoomAndIsActiveTrue(ChatRoom chatRoom);
 
     Long countByChatRoom(ChatRoom chatRoom);
 }


### PR DESCRIPTION
## 📄 feat : 채팅방 상세 정보 조회 기능 구현
- 채팅방 상세 정보 조회 기능 구현
- 채팅방의 이름, 고유 코드, 참여중인 참여자 목록이 반환됨.

## 📌 변경 사항
- 채팅방 상세 정보 기능 구현

## 🔍 주요 변경 파일 및 내용
- [x] `ChatRoomController.java` & `ChatRoomService.java` : 채팅방 상세 정보 조회 기능 구현.
- [x] `ParticipantRepository.java` : 채팅방의 `active` 상태인 참여자 list를 반환하는 메소드인 `findAllByChatRoomAndIsActiveTrue(ChatRoom chatRoom)` 를 추가함.
- [x] `ChatRoomInfoDto.java` : 채팅방의 이름, 고유 코드, 참여자 목록을 반환하기 위한 dto.

## ✅ 체크리스트
PR 제출 전 확인해야 할 사항:
- [x] 코드가 올바르게 동작하는지 확인
- [x] 테스트 코드 추가 및 정상 동작 확인
- [x] 문서 업데이트 여부 확인 (README, 위키 등)
- [x] 리뷰어에게 전달할 추가 정보 작성


## 📎 참고 자료
- 없어요!
