### PR TITLE
refactor : 채팅방 키워드 설정 방식 변경

### DIFF
--- a/src/main/java/ewha/capston/cockChat/domain/chat/controller/ChatRoomParticipantController.java
+++ b/src/main/java/ewha/capston/cockChat/domain/chat/controller/ChatRoomParticipantController.java
@@ -28,11 +28,13 @@ public class ChatRoomParticipantController {
     }
 
     /* 채팅방 설정 */
+    /*
     @PutMapping("/{chatRoomId}/settings")
     public ResponseEntity<ChatRoomSettingResponseDto> updateSettings(@AuthUser Member member, @PathVariable(name = "chatRoomId") Long chatRoomId
     , @RequestBody ChatRoomSettingRequestDto requestDto){
         return chatRoomParticipantService.updateSettings(member,chatRoomId,requestDto);
     }
+     */
 
     /* 채팅방 방장 변경 */
     @PutMapping("/{chatRoomId}/owner")

--- a/src/main/java/ewha/capston/cockChat/domain/chat/dto/ChatRoomSettingResponseDto.java
+++ b/src/main/java/ewha/capston/cockChat/domain/chat/dto/ChatRoomSettingResponseDto.java
@@ -14,6 +14,7 @@ public class ChatRoomSettingResponseDto {
     private String positiveKeywords;
     private String negativeKeywords;
 
+    /*
     public static ChatRoomSettingResponseDto of(Participant participant){
         return ChatRoomSettingResponseDto
                 .builder()
@@ -22,4 +23,5 @@ public class ChatRoomSettingResponseDto {
                 .negativeKeywords(participant.getNegativeKeywords())
                 .build();
     }
+     */
 }

--- a/src/main/java/ewha/capston/cockChat/domain/chat/service/ChatRoomParticipantService.java
+++ b/src/main/java/ewha/capston/cockChat/domain/chat/service/ChatRoomParticipantService.java
@@ -66,6 +66,7 @@ public class ChatRoomParticipantService {
     }
 
     /* 채팅방 환경 설정 수정 */
+    /*
     public ResponseEntity<ChatRoomSettingResponseDto> updateSettings(Member member, Long chatRoomId, ChatRoomSettingRequestDto requestDto) {
         ChatRoom chatRoom = chatRoomRepository.findById(chatRoomId)
                 .orElseThrow(()->new CustomException(ErrorCode.INVALID_ROOM));
@@ -75,6 +76,8 @@ public class ChatRoomParticipantService {
         return ResponseEntity.status(HttpStatus.OK)
                 .body(ChatRoomSettingResponseDto.of(participant));
     }
+
+     */
 
     /* 채팅방 방장 변경 */
     public ResponseEntity<ParticipantResponseDto> updateOwner(Member member, Long chatRoomId, OwnerRequestDto requestDto) {

--- a/src/main/java/ewha/capston/cockChat/domain/participant/controller/ParticipantController.java
+++ b/src/main/java/ewha/capston/cockChat/domain/participant/controller/ParticipantController.java
@@ -7,7 +7,6 @@ import ewha.capston.cockChat.domain.participant.dto.ParticipantAnonymousRequestD
 import ewha.capston.cockChat.domain.participant.dto.ParticipantResponseDto;
 import ewha.capston.cockChat.domain.participant.service.ParticipantService;
 import ewha.capston.cockChat.global.config.auth.AuthUser;
-import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;

--- a/src/main/java/ewha/capston/cockChat/domain/participant/controller/ParticipantKeywordController.java
+++ b/src/main/java/ewha/capston/cockChat/domain/participant/controller/ParticipantKeywordController.java
@@ -1,0 +1,31 @@
+package ewha.capston.cockChat.domain.participant.controller;
+
+import ewha.capston.cockChat.domain.member.domain.Member;
+import ewha.capston.cockChat.domain.participant.dto.KeywordInfoDto;
+import ewha.capston.cockChat.domain.participant.dto.KeywordResponseDto;
+import ewha.capston.cockChat.domain.participant.service.ParticipantKeywordService;
+import ewha.capston.cockChat.global.config.auth.AuthUser;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping
+public class ParticipantKeywordController {
+    private final ParticipantKeywordService participantKeywordService;
+
+    /* 긍정 키워드 추가 */
+    @PostMapping("/participants/{participantId}/positive-keyword")
+    public ResponseEntity<KeywordResponseDto> createPositiveKeyword(@AuthUser Member member, @PathVariable(name = "participantId") Long participantId, @RequestBody KeywordInfoDto requestDto){
+        return participantKeywordService.createPositiveKeyword(member, participantId, requestDto);
+    }
+
+    /* 부정 키워드 추가 */
+    @PostMapping("/participants/{participantId}/negative-keyword")
+    public ResponseEntity<KeywordResponseDto> createNegativeKeyword(@AuthUser Member member, @PathVariable(name = "participantId") Long participantId, @RequestBody KeywordInfoDto requestDto){
+        return participantKeywordService.createNegativeKeyword(member, participantId, requestDto);
+    }
+}

--- a/src/main/java/ewha/capston/cockChat/domain/participant/domain/Participant.java
+++ b/src/main/java/ewha/capston/cockChat/domain/participant/domain/Participant.java
@@ -21,12 +21,17 @@ public class Participant {
     @Column
     private Boolean isOwner;
 
+    /*
+
+    테이블 분리하여 관리
+
     @Column
     private String positiveKeywords;
 
     @Column
     private String negativeKeywords;
 
+     */
     @Column
     private String roomNickname;
 
@@ -54,11 +59,15 @@ public class Participant {
         this.member = member;
     }
 
+
     /* 키워드 설정 업데이트 */
+    /*
     public void updateSettings(String positiveKeywords, String negativeKeywords){
         this.positiveKeywords = positiveKeywords;
         this.negativeKeywords = negativeKeywords;
     }
+    */
+
 
     /* 방장 권한 업데이트 */
     public void updateIsOwner(Boolean isOwner){

--- a/src/main/java/ewha/capston/cockChat/domain/participant/domain/ParticipantNegativeKeyword.java
+++ b/src/main/java/ewha/capston/cockChat/domain/participant/domain/ParticipantNegativeKeyword.java
@@ -1,0 +1,32 @@
+package ewha.capston.cockChat.domain.participant.domain;
+
+import ewha.capston.cockChat.domain.member.domain.Member;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ParticipantNegativeKeyword {
+
+    @Id
+    @Column
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long negativeKeywordId;
+
+    @ManyToOne
+    @JoinColumn(name = "participant_id")
+    private Participant participant;
+
+    @Column(nullable = false)
+    private String content;
+
+    @Builder
+    public ParticipantNegativeKeyword(Participant participant, String content){
+        this.participant = participant;
+        this.content = content;
+    }
+}

--- a/src/main/java/ewha/capston/cockChat/domain/participant/domain/ParticipantPositiveKeyword.java
+++ b/src/main/java/ewha/capston/cockChat/domain/participant/domain/ParticipantPositiveKeyword.java
@@ -1,0 +1,31 @@
+package ewha.capston.cockChat.domain.participant.domain;
+
+import ewha.capston.cockChat.domain.member.domain.Member;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ParticipantPositiveKeyword {
+    @Id
+    @Column
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long positiveKeywordId;
+
+    @ManyToOne
+    @JoinColumn(name = "participant_id")
+    private Participant participant;
+
+    @Column(nullable = false)
+    private String content;
+
+    @Builder
+    public ParticipantPositiveKeyword(Participant participant, String content){
+        this.participant = participant;
+        this.content = content;
+    }
+}

--- a/src/main/java/ewha/capston/cockChat/domain/participant/dto/KeywordInfoDto.java
+++ b/src/main/java/ewha/capston/cockChat/domain/participant/dto/KeywordInfoDto.java
@@ -1,0 +1,14 @@
+package ewha.capston.cockChat.domain.participant.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class KeywordInfoDto {
+    private String keyword;
+}

--- a/src/main/java/ewha/capston/cockChat/domain/participant/dto/KeywordResponseDto.java
+++ b/src/main/java/ewha/capston/cockChat/domain/participant/dto/KeywordResponseDto.java
@@ -1,0 +1,21 @@
+package ewha.capston.cockChat.domain.participant.dto;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+public class KeywordResponseDto {
+    private Long keywordId;
+    private String content;
+
+    public static KeywordResponseDto of(Long keywordId, String content){
+        return KeywordResponseDto.builder()
+                .keywordId(keywordId)
+                .content(content)
+                .build();
+    }
+}

--- a/src/main/java/ewha/capston/cockChat/domain/participant/repository/ParticipantNegativeKeywordRepository.java
+++ b/src/main/java/ewha/capston/cockChat/domain/participant/repository/ParticipantNegativeKeywordRepository.java
@@ -1,0 +1,9 @@
+package ewha.capston.cockChat.domain.participant.repository;
+
+import ewha.capston.cockChat.domain.participant.domain.Participant;
+import ewha.capston.cockChat.domain.participant.domain.ParticipantNegativeKeyword;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ParticipantNegativeKeywordRepository extends JpaRepository<ParticipantNegativeKeyword, Long> {
+    Long countByParticipant(Participant participant);
+}

--- a/src/main/java/ewha/capston/cockChat/domain/participant/repository/ParticipantPositiveKeywordRepository.java
+++ b/src/main/java/ewha/capston/cockChat/domain/participant/repository/ParticipantPositiveKeywordRepository.java
@@ -1,0 +1,11 @@
+package ewha.capston.cockChat.domain.participant.repository;
+
+
+import ewha.capston.cockChat.domain.member.domain.Member;
+import ewha.capston.cockChat.domain.participant.domain.Participant;
+import ewha.capston.cockChat.domain.participant.domain.ParticipantPositiveKeyword;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ParticipantPositiveKeywordRepository extends JpaRepository<ParticipantPositiveKeyword, Long> {
+    Long countByParticipant(Participant participant);
+}

--- a/src/main/java/ewha/capston/cockChat/domain/participant/service/ParticipantKeywordService.java
+++ b/src/main/java/ewha/capston/cockChat/domain/participant/service/ParticipantKeywordService.java
@@ -1,0 +1,62 @@
+package ewha.capston.cockChat.domain.participant.service;
+
+import ewha.capston.cockChat.domain.member.domain.Member;
+import ewha.capston.cockChat.domain.participant.domain.Participant;
+import ewha.capston.cockChat.domain.participant.domain.ParticipantNegativeKeyword;
+import ewha.capston.cockChat.domain.participant.domain.ParticipantPositiveKeyword;
+import ewha.capston.cockChat.domain.participant.dto.KeywordInfoDto;
+import ewha.capston.cockChat.domain.participant.dto.KeywordResponseDto;
+import ewha.capston.cockChat.domain.participant.repository.ParticipantNegativeKeywordRepository;
+import ewha.capston.cockChat.domain.participant.repository.ParticipantPositiveKeywordRepository;
+import ewha.capston.cockChat.domain.participant.repository.ParticipantRepository;
+import ewha.capston.cockChat.global.exception.CustomException;
+import ewha.capston.cockChat.global.exception.ErrorCode;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class ParticipantKeywordService {
+
+    private final ParticipantRepository participantRepository;
+    private final ParticipantPositiveKeywordRepository positiveKeywordRepository;
+    private final ParticipantNegativeKeywordRepository negativeKeywordRepository;
+
+    /* 긍정 키워드 설정 */
+    public ResponseEntity<KeywordResponseDto> createPositiveKeyword(Member member, Long participantId, KeywordInfoDto requestDto) {
+        Participant participant = participantRepository.findById(participantId)
+                .orElseThrow(()-> new CustomException(ErrorCode.INVALID_PARTICIPANT));
+        if(!participant.getMember().equals(member)) throw new CustomException(ErrorCode.INVALID_MEMBER);
+        if(positiveKeywordRepository.countByParticipant(participant) > 5L) throw new CustomException(ErrorCode.EXCEEDED_KEYWORD_LIMIT);
+        ParticipantPositiveKeyword positiveKeyword = positiveKeywordRepository.save(
+                ParticipantPositiveKeyword.builder()
+                        .participant(participant)
+                        .content(requestDto.getKeyword())
+                        .build()
+        );
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(KeywordResponseDto.of(positiveKeyword.getPositiveKeywordId(), positiveKeyword.getContent()));
+    }
+
+    /* 부정 키워드 설정 */
+    public ResponseEntity<KeywordResponseDto> createNegativeKeyword(Member member, Long participantId, KeywordInfoDto requestDto) {
+        Participant participant = participantRepository.findById(participantId)
+                .orElseThrow(()->new CustomException(ErrorCode.INVALID_PARTICIPANT));
+        if(!participant.getMember().equals(member)) throw new CustomException(ErrorCode.INVALID_MEMBER);
+        if(negativeKeywordRepository.countByParticipant(participant) > 5L) throw new CustomException(ErrorCode.EXCEEDED_KEYWORD_LIMIT);
+        ParticipantNegativeKeyword negativeKeyword = negativeKeywordRepository.save(
+                ParticipantNegativeKeyword.builder()
+                        .participant(participant)
+                        .content(requestDto.getKeyword())
+                        .build()
+        );
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(KeywordResponseDto.of(negativeKeyword.getNegativeKeywordId(),negativeKeyword.getContent()));
+    }
+}

--- a/src/main/java/ewha/capston/cockChat/global/config/SecurityConfig.java
+++ b/src/main/java/ewha/capston/cockChat/global/config/SecurityConfig.java
@@ -64,7 +64,8 @@ public class SecurityConfig {
         http.csrf(csrf -> csrf.disable())
                 .cors(cors -> cors.configurationSource(request -> {
                     CorsConfiguration corsConfig = new CorsConfiguration();
-                    corsConfig.setAllowedOrigins(Arrays.asList("http://localhost:63342","http://localhost:3000", "https://chatcipe.o-r.kr", "wss://chatcipe.o-r.kr")); // 3000 포트 허용
+                    corsConfig.setAllowedOrigins(Arrays.asList("http://localhost:63342","http://localhost:3000",
+                            "https://chatcipe.o-r.kr", "wss://chatcipe.o-r.kr", "https://chatcipe.vercel.app ")); // 3000 포트 허용
                     corsConfig.setAllowedMethods(Arrays.asList("GET", "POST", "OPTIONS", "PUT", "DELETE")); // 허용할 HTTP 메소드
                     corsConfig.setAllowCredentials(true); // 쿠키나 인증 헤더를 포함할 수 있도록 설정
                     corsConfig.setAllowedHeaders(Arrays.asList("Authorization", "Content-Type")); // 허용할 헤더

--- a/src/main/java/ewha/capston/cockChat/global/exception/ErrorCode.java
+++ b/src/main/java/ewha/capston/cockChat/global/exception/ErrorCode.java
@@ -32,6 +32,9 @@ public enum ErrorCode {
     CANNOT_REMOVE_OWNER(HttpStatus.BAD_REQUEST, "방장은 탈퇴할 수 없습니다."),
     NOT_A_ANONYMOUS(HttpStatus.BAD_REQUEST,"익명 참여자가 아닙니다"),
 
+    /* keyword */
+    EXCEEDED_KEYWORD_LIMIT(HttpStatus.BAD_REQUEST, "저장 가능한 키워드 수를 초과하였습니다."),
+
     /* file */
     INPUT_IS_NULL(HttpStatus.BAD_REQUEST,"입력으로 null이 들어왔습니다."),
     FILE_DELETE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR,"파일 삭제에 실패했습니다."),


### PR DESCRIPTION
## 📄 refactor : 채팅방 키워드 설정 방식 변경
- 채팅방 키워드 설정 방식을 변경함. 기존 키워드를 `,` 를 기준으로 구분하여 한번에 입력받았다면 각각 입력받도록 수정함.

## 📌 변경 사항
- 기존 Participant 에서 keyword 필드를 삭제하고, 대신 `ParticipantPositiveKeyword` 와 `ParticipantNegativeKeyword` 로 분리하여 관리하도록 수정함.
- 키워드 생성 시 한번에 키워드 한 개만 생성할 수 있도록 수정함.
- 만약 기존에 존재하는 키워드가 이미 5개라면, 더 이상 키워드가 생성될 수 없으므로 예외를 발생시킴.
- cors 허용 경로 추가.

## 🔍 주요 변경 파일 및 내용
- [ ] `ChatRoomParticipantController.java` &`ChatRoomParticipantService.java` & `Participant.java` : 기존 방식의 코드를 주석처리함.
- [ ] `ParticipantPositiveKeyword.java` & `ParticipantNegative.java` : 긍정 키워드, 부정 키워드를 테이블을 분리하여 관리하도록 함.
- [ ] `ParticipantKeywordController.java` & `ParticipantKeywordService.java` : 긍정 키워드, 부정 키워드 설정 기능 구현


## ✅ 체크리스트
PR 제출 전 확인해야 할 사항:
- [ ] 코드가 올바르게 동작하는지 확인
- [ ] 테스트 코드 추가 및 정상 동작 확인
- [ ] 문서 업데이트 여부 확인 (README, 위키 등)
- [ ] 리뷰어에게 전달할 추가 정보 작성


## 📎 참고 자료
- 없어요!