### PR TITLE
refactor : 채팅 응답 필드에 sender 정보 추가

### DIFF
--- a/src/main/java/ewha/capston/cockChat/domain/chat/controller/ChatController.java
+++ b/src/main/java/ewha/capston/cockChat/domain/chat/controller/ChatController.java
@@ -1,15 +1,13 @@
 package ewha.capston.cockChat.domain.chat.controller;
 
-import ewha.capston.cockChat.domain.chat.dto.ChatMessageRequestDto;
-import ewha.capston.cockChat.domain.chat.dto.ChatResponseDto;
+import ewha.capston.cockChat.domain.chat.dto.reqeust.ChatMessageRequestDto;
+import ewha.capston.cockChat.domain.chat.dto.response.ChatResponseDto;
 import ewha.capston.cockChat.domain.chat.service.ChatService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
-import org.springframework.messaging.handler.annotation.DestinationVariable;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.handler.annotation.Payload;
-import org.springframework.messaging.handler.annotation.SendTo;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;

--- a/src/main/java/ewha/capston/cockChat/domain/chat/controller/ChatRoomController.java
+++ b/src/main/java/ewha/capston/cockChat/domain/chat/controller/ChatRoomController.java
@@ -1,8 +1,8 @@
 package ewha.capston.cockChat.domain.chat.controller;
 
-import ewha.capston.cockChat.domain.chat.dto.ChatRoomInfoDto;
-import ewha.capston.cockChat.domain.chat.dto.ChatRoomRequestDto;
-import ewha.capston.cockChat.domain.chat.dto.ChatRoomResponseDto;
+import ewha.capston.cockChat.domain.chat.dto.response.ChatRoomInfoDto;
+import ewha.capston.cockChat.domain.chat.dto.reqeust.ChatRoomRequestDto;
+import ewha.capston.cockChat.domain.chat.dto.response.ChatRoomResponseDto;
 import ewha.capston.cockChat.domain.chat.service.ChatRoomService;
 import ewha.capston.cockChat.domain.chat.service.ChatService;
 import ewha.capston.cockChat.domain.member.domain.Member;
@@ -62,10 +62,14 @@ public class ChatRoomController {
     }
 
     /* mongoDB 테스트 */
+
+    /*
     @PostMapping("/chat/test")
     public ResponseEntity testMongo(){
         chatService.mongoDBConnectionTest();
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body("성공");
     }
+
+     */
 }

--- a/src/main/java/ewha/capston/cockChat/domain/chat/controller/ChatRoomParticipantController.java
+++ b/src/main/java/ewha/capston/cockChat/domain/chat/controller/ChatRoomParticipantController.java
@@ -1,8 +1,6 @@
 package ewha.capston.cockChat.domain.chat.controller;
 
-import ewha.capston.cockChat.domain.chat.dto.ChatRoomResponseDto;
-import ewha.capston.cockChat.domain.chat.dto.ChatRoomSettingRequestDto;
-import ewha.capston.cockChat.domain.chat.dto.ChatRoomSettingResponseDto;
+import ewha.capston.cockChat.domain.chat.dto.response.ChatRoomResponseDto;
 import ewha.capston.cockChat.domain.chat.service.ChatRoomParticipantService;
 import ewha.capston.cockChat.domain.member.domain.Member;
 import ewha.capston.cockChat.domain.participant.dto.OwnerRequestDto;

--- a/src/main/java/ewha/capston/cockChat/domain/chat/domain/Chat.java
+++ b/src/main/java/ewha/capston/cockChat/domain/chat/domain/Chat.java
@@ -32,5 +32,4 @@ public class Chat extends BaseTimeEntity{
         this.message = message;
         this.participantId = participantId;
     }
-
 }

--- a/src/main/java/ewha/capston/cockChat/domain/chat/dto/reqeust/ChatMessageRequestDto.java
+++ b/src/main/java/ewha/capston/cockChat/domain/chat/dto/reqeust/ChatMessageRequestDto.java
@@ -1,4 +1,4 @@
-package ewha.capston.cockChat.domain.chat.dto;
+package ewha.capston.cockChat.domain.chat.dto.reqeust;
 
 import ewha.capston.cockChat.domain.chat.domain.MessageType;
 import lombok.AccessLevel;

--- a/src/main/java/ewha/capston/cockChat/domain/chat/dto/reqeust/ChatRoomRequestDto.java
+++ b/src/main/java/ewha/capston/cockChat/domain/chat/dto/reqeust/ChatRoomRequestDto.java
@@ -1,4 +1,4 @@
-package ewha.capston.cockChat.domain.chat.dto;
+package ewha.capston.cockChat.domain.chat.dto.reqeust;
 
 
 import lombok.AccessLevel;

--- a/src/main/java/ewha/capston/cockChat/domain/chat/dto/reqeust/ChatRoomSettingRequestDto.java
+++ b/src/main/java/ewha/capston/cockChat/domain/chat/dto/reqeust/ChatRoomSettingRequestDto.java
@@ -1,4 +1,4 @@
-package ewha.capston.cockChat.domain.chat.dto;
+package ewha.capston.cockChat.domain.chat.dto.reqeust;
 
 import lombok.Getter;
 import lombok.NoArgsConstructor;

--- a/src/main/java/ewha/capston/cockChat/domain/chat/dto/response/ChatResponseDto.java
+++ b/src/main/java/ewha/capston/cockChat/domain/chat/dto/response/ChatResponseDto.java
@@ -1,7 +1,8 @@
-package ewha.capston.cockChat.domain.chat.dto;
+package ewha.capston.cockChat.domain.chat.dto.response;
 
 import ewha.capston.cockChat.domain.chat.domain.Chat;
 import ewha.capston.cockChat.domain.chat.domain.MessageType;
+import ewha.capston.cockChat.domain.participant.domain.Participant;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -15,14 +16,18 @@ import java.time.LocalDateTime;
 public class ChatResponseDto {
     private Long roomId;
     private Long senderId;
+    private String senderNickname;
+    private String senderImgUrl;
     private MessageType type;
     private String content;
     private LocalDateTime createdAt;
 
-    public static ChatResponseDto of(Chat chat){
+    public static ChatResponseDto of(Chat chat, Participant participant){
         return ChatResponseDto.builder()
                 .roomId(chat.getChatroomId())
                 .senderId(chat.getParticipantId())
+                .senderNickname(participant.getRoomNickname())
+                .senderImgUrl(participant.getParticipantImgUrl())
                 .type(chat.getMessageType())
                 .content(chat.getMessage())
                 .createdAt(chat.getCreatedDate())

--- a/src/main/java/ewha/capston/cockChat/domain/chat/dto/response/ChatRoomInfoDto.java
+++ b/src/main/java/ewha/capston/cockChat/domain/chat/dto/response/ChatRoomInfoDto.java
@@ -1,7 +1,6 @@
-package ewha.capston.cockChat.domain.chat.dto;
+package ewha.capston.cockChat.domain.chat.dto.response;
 
 import ewha.capston.cockChat.domain.chat.domain.ChatRoom;
-import ewha.capston.cockChat.domain.participant.domain.Participant;
 import ewha.capston.cockChat.domain.participant.dto.ParticipantResponseDto;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;

--- a/src/main/java/ewha/capston/cockChat/domain/chat/dto/response/ChatRoomResponseDto.java
+++ b/src/main/java/ewha/capston/cockChat/domain/chat/dto/response/ChatRoomResponseDto.java
@@ -1,7 +1,8 @@
-package ewha.capston.cockChat.domain.chat.dto;
+package ewha.capston.cockChat.domain.chat.dto.response;
 
 import ewha.capston.cockChat.domain.chat.domain.Chat;
 import ewha.capston.cockChat.domain.chat.domain.ChatRoom;
+import ewha.capston.cockChat.domain.participant.domain.Participant;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -22,7 +23,7 @@ public class ChatRoomResponseDto {
     private Long participantCount;
     private ChatResponseDto latestChat;
 
-    public static ChatRoomResponseDto of(ChatRoom chatRoom, Long participantCount, Chat chat){
+    public static ChatRoomResponseDto of(ChatRoom chatRoom, Long participantCount, Chat chat, Participant sender){
         return ChatRoomResponseDto.builder()
                 .roomId(chatRoom.getRoomId())
                 .identifier(chatRoom.getIdentifier())
@@ -32,7 +33,7 @@ public class ChatRoomResponseDto {
                 .isAnonymousChatRoom(chatRoom.getIsAnonymousChatRoom())
                 .chatRoomImgUrl(chatRoom.getChatRoomImgUrl())
                 .participantCount(participantCount)
-                .latestChat(chat != null ? ChatResponseDto.of(chat) : null)
+                .latestChat(chat != null ? ChatResponseDto.of(chat,sender) : null)
                 .build();
     }
 }

--- a/src/main/java/ewha/capston/cockChat/domain/chat/dto/response/ChatRoomSettingResponseDto.java
+++ b/src/main/java/ewha/capston/cockChat/domain/chat/dto/response/ChatRoomSettingResponseDto.java
@@ -1,4 +1,4 @@
-package ewha.capston.cockChat.domain.chat.dto;
+package ewha.capston.cockChat.domain.chat.dto.response;
 
 import ewha.capston.cockChat.domain.participant.domain.Participant;
 import lombok.AccessLevel;

--- a/src/main/java/ewha/capston/cockChat/domain/chat/service/ChatRoomParticipantService.java
+++ b/src/main/java/ewha/capston/cockChat/domain/chat/service/ChatRoomParticipantService.java
@@ -1,12 +1,9 @@
 package ewha.capston.cockChat.domain.chat.service;
 
 import ewha.capston.cockChat.domain.chat.domain.ChatRoom;
-import ewha.capston.cockChat.domain.chat.dto.ChatRoomResponseDto;
-import ewha.capston.cockChat.domain.chat.dto.ChatRoomSettingRequestDto;
-import ewha.capston.cockChat.domain.chat.dto.ChatRoomSettingResponseDto;
+import ewha.capston.cockChat.domain.chat.dto.response.ChatRoomResponseDto;
 import ewha.capston.cockChat.domain.chat.repository.ChatRoomRepository;
 import ewha.capston.cockChat.domain.member.domain.Member;
-import ewha.capston.cockChat.domain.member.repository.MemberRepository;
 import ewha.capston.cockChat.domain.participant.domain.Participant;
 import ewha.capston.cockChat.domain.participant.dto.OwnerRequestDto;
 import ewha.capston.cockChat.domain.participant.dto.ParticipantResponseDto;

--- a/src/main/java/ewha/capston/cockChat/domain/chat/service/ChatRoomService.java
+++ b/src/main/java/ewha/capston/cockChat/domain/chat/service/ChatRoomService.java
@@ -2,9 +2,9 @@ package ewha.capston.cockChat.domain.chat.service;
 
 import ewha.capston.cockChat.domain.chat.domain.Chat;
 import ewha.capston.cockChat.domain.chat.domain.ChatRoom;
-import ewha.capston.cockChat.domain.chat.dto.ChatRoomInfoDto;
-import ewha.capston.cockChat.domain.chat.dto.ChatRoomRequestDto;
-import ewha.capston.cockChat.domain.chat.dto.ChatRoomResponseDto;
+import ewha.capston.cockChat.domain.chat.dto.response.ChatRoomInfoDto;
+import ewha.capston.cockChat.domain.chat.dto.reqeust.ChatRoomRequestDto;
+import ewha.capston.cockChat.domain.chat.dto.response.ChatRoomResponseDto;
 import ewha.capston.cockChat.domain.chat.mongo.MongoChatRepository;
 import ewha.capston.cockChat.domain.chat.repository.ChatRoomRepository;
 import ewha.capston.cockChat.domain.member.domain.Member;
@@ -132,6 +132,9 @@ public class ChatRoomService {
 
     /* chatRoomResponseDto 생성 */
     public ChatRoomResponseDto makeChatRoomResponseDto(ChatRoom chatRoom){
-        return ChatRoomResponseDto.of(chatRoom,participantRepository.countByChatRoom(chatRoom),mongoChatRepository.findTopByChatroomIdOrderByCreatedDateDesc(chatRoom.getRoomId()));
+        Chat latestChat =  mongoChatRepository.findTopByChatroomIdOrderByCreatedDateDesc(chatRoom.getRoomId());
+        Participant sender = participantRepository.findById(latestChat.getParticipantId())
+                .orElseThrow(()->new CustomException(ErrorCode.INVALID_PARTICIPANT));
+        return ChatRoomResponseDto.of(chatRoom,participantRepository.countByChatRoom(chatRoom),latestChat,sender);
     }
 }

--- a/src/main/java/ewha/capston/cockChat/domain/participant/service/ParticipantService.java
+++ b/src/main/java/ewha/capston/cockChat/domain/participant/service/ParticipantService.java
@@ -49,7 +49,6 @@ public class ParticipantService {
 
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(ParticipantResponseDto.of(participant));
-
     }
 
     /* 익명 채팅방 신규 입장 */


### PR DESCRIPTION
## 📄 feat: 채팅 응답 필드에 sender 정보 추가
- 채팅 응답 필드에 senderNickname과 senderImgUrl 을 추가로 반환함.

## 📌 변경 사항
- 채팅 메시지 응답에 senderNickname, senderImgUrl 필드 추가

- senderId를 기반으로 MySQL에서 sender 정보를 조회하여 매핑

- Collectors.toMap()을 사용하여 sender 정보를 효율적으로 변환

## 🔍 주요 변경 파일 및 내용
- [ ] `ChatResponseDto.java` : `senderNickname`, `senderImgUrl` 필드 추가
- [ ] `ChatRoomService.java`: `makeDto()` 메소드 수정.
- [ ]  `ChatService.java` : senderId를 이용해 MySQL에서 sender 정보 조회 후 매핑

## ✅ 체크리스트
PR 제출 전 확인해야 할 사항:
- [ ] 코드가 올바르게 동작하는지 확인
- [ ] 테스트 코드 추가 및 정상 동작 확인
- [ ] 문서 업데이트 여부 확인 (README, 위키 등)
- [ ] 리뷰어에게 전달할 추가 정보 작성


## 📎 참고 자료
-  없어요!
