### PR TITLE
feat : 알림 읽음 처리 기능 구현, 채팅 응답 필드 추가

### DIFF
--- a/src/main/java/ewha/capston/cockChat/domain/chat/dto/response/ChatResponseDto.java
+++ b/src/main/java/ewha/capston/cockChat/domain/chat/dto/response/ChatResponseDto.java
@@ -16,6 +16,7 @@ import java.time.LocalDateTime;
 public class ChatResponseDto {
     private Long roomId;
     private Long senderId;
+    private String chatId;
     private String senderNickname;
     private String senderImgUrl;
     private MessageType type;
@@ -26,6 +27,7 @@ public class ChatResponseDto {
         return ChatResponseDto.builder()
                 .roomId(chat.getChatroomId())
                 .senderId(chat.getParticipantId())
+                .chatId(chat.getId())
                 .senderNickname(participant.getRoomNickname())
                 .senderImgUrl(participant.getParticipantImgUrl())
                 .type(chat.getMessageType())

--- a/src/main/java/ewha/capston/cockChat/domain/notification/controller/NotificationController.java
+++ b/src/main/java/ewha/capston/cockChat/domain/notification/controller/NotificationController.java
@@ -6,11 +6,10 @@ import ewha.capston.cockChat.domain.notification.service.NotificationService;
 import ewha.capston.cockChat.global.config.auth.AuthUser;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
+import java.util.Objects;
 
 @RestController
 @RequiredArgsConstructor
@@ -19,9 +18,16 @@ public class NotificationController {
 
     private final NotificationService notificationService;
 
+    /* 사용자 맞춤 알림 목록 조회 */
     @GetMapping("/members/notifications")
     public ResponseEntity<List<NotificationResponseDto>> getMemberNotificationList(@AuthUser Member member){
         return notificationService.getMemberNotificationList(member);
+    }
+
+    /* 알림 읽음 처리 */
+    @DeleteMapping("/members/notifications/{notificationId}/read")
+    public ResponseEntity<Object> markNotificationAsRead(@AuthUser Member member, @PathVariable(name = "notificationId") String notificationId){
+        return notificationService.markNotificationAsRead(member,notificationId);
     }
 
 

--- a/src/main/java/ewha/capston/cockChat/domain/notification/dto/NotificationResponseDto.java
+++ b/src/main/java/ewha/capston/cockChat/domain/notification/dto/NotificationResponseDto.java
@@ -1,6 +1,7 @@
 package ewha.capston.cockChat.domain.notification.dto;
 
 import ewha.capston.cockChat.domain.chat.domain.Chat;
+import ewha.capston.cockChat.domain.chat.domain.ChatRoom;
 import ewha.capston.cockChat.domain.notification.domain.Notification;
 import ewha.capston.cockChat.domain.participant.domain.ParticipantPositiveKeyword;
 import lombok.AccessLevel;
@@ -16,15 +17,17 @@ public class NotificationResponseDto {
     private String keyword; // 키워드 내용
     private String chatId; // 채팅 id
     private Long chatRoomId; // 채팅 발생 채팅방 id
+    private String chatRoomName;
     private Long participantId; // 알림 소유자 participant Id
     private boolean isRead; // 채팅 확인 여부
 
-    public static NotificationResponseDto of(Notification notification, Chat chat, ParticipantPositiveKeyword positiveKeyword, boolean isRead){
+    public static NotificationResponseDto of(Notification notification, Chat chat, ChatRoom chatRoom, ParticipantPositiveKeyword positiveKeyword, boolean isRead){
         return NotificationResponseDto.builder()
                 .notificationId(notification.getId())
                 .keyword(positiveKeyword.getContent())
                 .chatId(chat.getId())
                 .chatRoomId(chat.getChatroomId())
+                .chatRoomName(chatRoom.getRoomName())
                 .participantId(positiveKeyword.getParticipant().getParticipantId())
                 .isRead(isRead)
                 .build();

--- a/src/main/java/ewha/capston/cockChat/global/exception/ErrorCode.java
+++ b/src/main/java/ewha/capston/cockChat/global/exception/ErrorCode.java
@@ -42,8 +42,10 @@ public enum ErrorCode {
     FILE_DELETE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR,"파일 삭제에 실패했습니다."),
     NO_CONTENT_EXIST(HttpStatus.BAD_REQUEST,"존재하지 않습니다."),
 
-    SESSION_ATTRIBUTE_IS_NULL(HttpStatus.BAD_REQUEST, "SessionAttributes가 null입니다.")
+    SESSION_ATTRIBUTE_IS_NULL(HttpStatus.BAD_REQUEST, "SessionAttributes가 null입니다."),
 
+    /* notification */
+    INVALID_NOTIFICATION(HttpStatus.BAD_REQUEST,"존재하지 않는 알림입니다. ")
 
     ;
 


### PR DESCRIPTION
## 📄 feat : 알림 읽음 처리 기능 구현, 채팅 응답 필드 추가
- 사용자 맞춤 알림 읽음 처리 기능 구현. (알림 삭제 기능)
- 채팅 응답 시 `chatId`를 함께 반환하도록 응답 필드 추가

## 📌 변경 사항
- 채팅 응답 필드 추가함.

## 🔍 주요 변경 파일 및 내용
- [ ] `NotificationControleller.java` & `NotificationService.java` : 알림 읽음 처리 기능 구현
- [ ] `ChatResponseDto.java` :  응답 필드로 `chatId` 추가함.

## ✅ 체크리스트
PR 제출 전 확인해야 할 사항:
- [ ] 코드가 올바르게 동작하는지 확인
- [ ] 테스트 코드 추가 및 정상 동작 확인
- [ ] 문서 업데이트 여부 확인 (README, 위키 등)
- [ ] 리뷰어에게 전달할 추가 정보 작성


## 📎 참고 자료
- 없어요!
